### PR TITLE
remove rxjava errorhandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ The Android OS maintains a table per device of the discovered service in cache. 
 await reactiveBleClient.clearGattCache('AA:BB:CC:DD:EE:FF');
 ```
 
+### Common issues
+
+#### BLE undeliverable exception
+On Android side we use the [RxAndroidBle](https://github.com/Polidea/RxAndroidBle) library of Polidea. After migration towards RxJava 2 some of the errors are not routed properly to their listeners and thus this will result in a BLE Undeliverable Exception. The root cause lies in the threading of the Android OS. As workaround RxJava has a hook where you can set the global errorhandler. For more info see [RxJava docs](https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling) .
+
+A default workaround implementation in the Flutter app (needs to be in the Java / Kotlin part e.g. mainactivity) would be:
+
+```kotlin
+RxJavaPlugins.setErrorHandler { throwable ->
+  if (throwable is UndeliverableException && throwable.cause is BleException) {
+    return@setErrorHandler // ignore BleExceptions since we do not have subscriber
+  }
+  else {
+    throw throwable
+  }
+}
+```
+
 
 
 

--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
@@ -1,7 +1,6 @@
 package com.signify.hue.flutterreactiveble
 
 import android.content.Context
-import com.polidea.rxandroidble2.exceptions.BleException
 import com.signify.hue.flutterreactiveble.ble.RequestConnectionPriorityFailed
 import com.signify.hue.flutterreactiveble.channelhandlers.BleStatusHandler
 import com.signify.hue.flutterreactiveble.channelhandlers.CharNotificationHandler
@@ -18,8 +17,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel.Result
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.exceptions.UndeliverableException
-import io.reactivex.plugins.RxJavaPlugins
 import timber.log.Timber
 import java.util.UUID
 import com.signify.hue.flutterreactiveble.ProtobufModel as pb
@@ -72,19 +69,6 @@ class PluginController {
         deviceConnectionChannel.setStreamHandler(deviceConnectionHandler)
         charNotificationChannel.setStreamHandler(charNotificationHandler)
         bleStatusChannel.setStreamHandler(bleStatusHandler)
-
-        /*Workaround for issue undeliverable https://github.com/Polidea/RxAndroidBle/wiki/FAQ:-UndeliverableException
-        note that this not override the onError for the observable only the RXJAVA error handler like described in:
-        https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling
-        */
-        RxJavaPlugins.setErrorHandler { throwable ->
-            if (throwable is UndeliverableException && throwable.cause is BleException) {
-                return@setErrorHandler // ignore BleExceptions as they were surely delivered at least once
-            }
-            // add other custom handlers if needed
-            @Suppress("TooGenericExceptionThrown")
-            throw RuntimeException("Unexpected Throwable in RxJavaPlugins error handler", throwable)
-        }
     }
 
     internal fun execute(call: MethodCall, result: Result) {


### PR DESCRIPTION
people that use library themselves should implement custom rx handler. Since it is a singleton we do not want to possibly override customhandlers