### PR TITLE
Add iOS Bluetooth usage description keys in the sample app

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+    <string>The app uses bluetooth to find, connect and transfer data between different devices</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>The app uses bluetooth to find, connect and transfer data between different devices</string>
 </dict>
 </plist>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -46,8 +46,8 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
-    <string>The app uses bluetooth to find, connect and transfer data between different devices</string>
-    <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>The app uses bluetooth to find, connect and transfer data between different devices</string>
+	<string>The app uses bluetooth to find, connect and transfer data between different devices</string>
+	<key>NSBluetoothPeripheralUsageDescription</key>
+	<string>The app uses bluetooth to find, connect and transfer data between different devices</string>
 </dict>
 </plist>


### PR DESCRIPTION
The usage description keys for Bluetooth are required since iOS 13 (I think). Without them, the sample app crashes immediately.

Resolves #14.