### PR TITLE
Revert removal of flutter dependency in root pubspec.yaml

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -163,7 +163,7 @@ packages:
     source: hosted
     version: "0.10.11"
   flutter:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ">=2.3.0-dev <3.0.0"
 
 dependencies:
+  flutter:
+    sdk: flutter
   functional_data: ^0.2.3
   protobuf: ^1.0.1
   meta: ^1.1.8


### PR DESCRIPTION
It seems that I cleaned-up a bit too much in my previous PR, although nothing (pub get, analyzer or tests) hinted that there was an issue.
It seems that we can't remove the flutter dependency from the package, even when it doesn't seem to depend on it... Now I can that it was a wrong assumption: tooling relies on it apparently.

Anyway, this could have been caught by running `flutter pub publish --dry-run`.
@remonh87, maybe you can add a step in the PR qualification pipeline to run this command.