### PR TITLE
Bugfix: check for correct property when trying to write w/o response

### DIFF
--- a/ios/Classes/ReactiveBle/Central.swift
+++ b/ios/Classes/ReactiveBle/Central.swift
@@ -234,7 +234,7 @@ final class Central {
     ) throws {
         let characteristic = try resolve(characteristic: qualifiedCharacteristic)
 
-        guard characteristic.properties.contains(.write)
+        guard characteristic.properties.contains(.writeWithoutResponse)
         else { throw Failure.notWritable(qualifiedCharacteristic) }
         
         characteristic.service.peripheral.writeValue(value, for: characteristic, type: .withoutResponse)


### PR DESCRIPTION
This commit fixes a problem when iOS devices try to write a value to characteristics, which have only a type of .writeWithoutResponse.