### PR TITLE
Don't pass stackTrace in EventSink.error

### DIFF
--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/channelhandlers/BleStatusHandler.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/channelhandlers/BleStatusHandler.kt
@@ -35,6 +35,6 @@ class BleStatusHandler(private val bleClient: BleClient) : EventChannel.StreamHa
                                 .build()
                         eventSink.success(message.toByteArray())
                     }, { throwable ->
-                        eventSink.error("ObserveBleStatusFailure", throwable.message, throwable.stackTrace)
+                        eventSink.error("ObserveBleStatusFailure", throwable.message, null)
                     })
 }


### PR DESCRIPTION
I see this error in crashlytics:
```
Caused by java.lang.IllegalArgumentException
Unsupported value: [Ljava.lang.StackTraceElement;@d0a315d
io.flutter.plugin.common.StandardMessageCodec.a

io.flutter.plugin.common.StandardMessageCodec.a (StandardMessageCodec.java:392)
io.flutter.plugin.common.StandardMethodCodec.a (StandardMethodCodec.java:37)
io.flutter.plugin.common.EventChannel$IncomingStreamRequestHandler$EventSinkImplementation.a (EventChannel.java:45)
com.signify.hue.flutterreactiveble.channelhandlers.BleStatusHandler$listenToBleStatus$3.accept (BleStatusHandler.java:17)
com.signify.hue.flutterreactiveble.channelhandlers.BleStatusHandler$listenToBleStatus$3.accept (BleStatusHandler.java:2)
io.reactivex.internal.observers.LambdaObserver.a (LambdaObserver.java:13)
io.reactivex.internal.observers.LambdaObserver.a (LambdaObserver.java:25)
io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.drainNormal (ObservableObserveOn.java:47)
io.reactivex.internal.operators.observable.ObservableObserveOn$ObserveOnObserver.run (ObservableObserveOn.java:8)
io.reactivex.android.schedulers.HandlerScheduler$ScheduledRunnable.run (HandlerScheduler.java:2)
```

It seems to point to this line.

I can try to "stringify" the stacktrace if you prefer. I guess there is a utility function to do that.

