### PR TITLE
added reference to external example flutter app

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,4 +220,4 @@ This will prevent issues like [#131](https://github.com/PhilipsHue/flutter_react
 
 #### Unofficial example apps
 
-[Example implementation UART over BLE:](https://github.com/wolfc01/flutter_reactive_ble_uart_example)
+Example implementation UART over BLE:[link](https://github.com/wolfc01/flutter_reactive_ble_uart_example)

--- a/README.md
+++ b/README.md
@@ -218,6 +218,6 @@ In case you are using ProGuard add the following snippet to your `proguard-rules
 
 This will prevent issues like [#131](https://github.com/PhilipsHue/flutter_reactive_ble/issues/131) .
 
-#### Further unofficial examples
+#### Unofficial example apps
 
-An example implementing an UART over BLE can be found at https://github.com/wolfc01/flutter_reactive_ble_uart_example
+[Example implementation UART over BLE:](https://github.com/wolfc01/flutter_reactive_ble_uart_example)

--- a/README.md
+++ b/README.md
@@ -217,3 +217,7 @@ In case you are using ProGuard add the following snippet to your `proguard-rules
 ```
 
 This will prevent issues like [#131](https://github.com/PhilipsHue/flutter_reactive_ble/issues/131) .
+
+#### Further unofficial examples
+
+An example implementing an UART over BLE can be found at https://github.com/wolfc01/flutter_reactive_ble_uart_example


### PR DESCRIPTION
Hello

@werediver @remonh87, as a follow up of https://github.com/PhilipsHue/flutter_reactive_ble/issues/170, and pull request https://github.com/PhilipsHue/flutter_reactive_ble/pull/178, I created a repository containing the example.

As a reminder, I created this pull request adding an reference to it in the READ.md file. I'm happy to receive review comments on this example.

Br
Carl.


