### PR TITLE
fix reinitializing of the eventchannel scanparameter by firebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.2
+
+* Fix #188 `subscribeToCharacteristic` fails when characteristic config descriptor is not present.
+* Fix #195 `scanFailure` when using backgroundmode messaging Firebase.
+
 ## 2.7.1
 
 * Fix #115 by updating to new protobuf lite on Android.

--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/channelhandlers/ScanDevicesHandler.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/channelhandlers/ScanDevicesHandler.kt
@@ -15,7 +15,10 @@ class ScanDevicesHandler(private val bleClient: com.signify.hue.flutterreactiveb
     private var scanDevicesSink: EventChannel.EventSink? = null
     private lateinit var scanForDevicesDisposable: Disposable
     private val converter = ProtobufMessageConverter()
-    private var scanParameters: ScanParameters? = null
+
+    companion object {
+        private var scanParameters: ScanParameters? = null
+    }
 
     override fun onListen(objectSink: Any?, eventSink: EventChannel.EventSink?) {
         eventSink?.let {
@@ -51,7 +54,7 @@ class ScanDevicesHandler(private val bleClient: com.signify.hue.flutterreactiveb
                 it.dispose()
                 scanParameters = null
             }
-       }
+        }
     }
 
     fun prepareScan(scanMessage: pb.ScanForDevicesRequest) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,7 +82,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.7.1"
+    version: "2.7.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reactive_ble_example
 description: Demonstrates how to use the flutter_reactive_ble plugin.
-version: 2.7.1
+version: 2.7.2
 publish_to: 'none'
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reactive_ble
 description: Reactive Bluetooth Low Energy (BLE) plugin that can communicate with multiple devices
-version: 2.7.1
+version: 2.7.2
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:


### PR DESCRIPTION
There is nothing wrong with the previous code however for some weird reason firebase resets state of the eventchannels which looks really fishy. Also there are quite some bugs there. This workaround however makes sense and guarantees good functioning state.

Fixes #195 