### PR TITLE
do not discover services when bonding is in progress

### DIFF
--- a/android/src/test/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClientTest.kt
+++ b/android/src/test/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClientTest.kt
@@ -1,5 +1,7 @@
 package com.signify.hue.flutterreactiveble.ble
 
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothDevice.BOND_BONDED
 import android.content.Context
 import com.google.common.truth.Truth.assertThat
 import com.polidea.rxandroidble2.RxBleClient
@@ -54,6 +56,9 @@ class ReactiveBleClientTest {
 
     @MockK
     private lateinit var bleDevice: RxBleDevice
+
+    @MockK
+    private lateinit var bluetoothDevice: BluetoothDevice
 
     @MockK
     lateinit var rxConnection: RxBleConnection
@@ -315,6 +320,12 @@ class ReactiveBleClientTest {
     @Nested
     @DisplayName("Discover services")
     inner class DiscoverServicesTest {
+
+        @BeforeEach
+        fun setup() {
+            every { bleDevice.bluetoothDevice }.returns(bluetoothDevice)
+            every {bluetoothDevice.bondState}.returns(BOND_BONDED)
+        }
 
         @Test
         fun `It returns success in case services can be discovered`() {


### PR DESCRIPTION
While dicovering services can result in interfering bonding using the just works principle as stated in: https://medium.com/@martijn.van.welie/making-android-ble-work-part-4-72a0b85cb442