### PR TITLE
Update doc-comments for `conectToDevice` and `connectToAdvertisingDevice`

### DIFF
--- a/lib/src/reactive_ble.dart
+++ b/lib/src/reactive_ble.dart
@@ -258,9 +258,9 @@ class FlutterReactiveBle {
   /// Use [servicesWithCharacteristicsToDiscover] to scan only for the specific services mentioned in this map,
   /// this can improve the connection speed on iOS since no full service discovery will be executed. On Android
   /// this variable is ignored since partial discovery is not possible.
-  /// The [connectionTimeout] parameter can be used to emit a failure after a certain period in case the connection
-  /// is not established. The pending connection attempt will be cancelled. On Android when no timeout is specified
-  /// the `autoConnect` flag is set in the [connectGatt()](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)) call, otherwise it's cleared.```
+  /// If [connectionTimeout] parameter is supplied and a connection is not established before the Duration expires,
+  /// a TimeoutException will be emit to the onError handler of the returned stream. The pending connection attempt will be cancelled.
+  /// On Android when no timeout is specified the `autoConnect` flag is set in the [connectGatt()](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)) call, otherwise it's cleared.```
 
   Stream<ConnectionStateUpdate> connectToDevice({
     required String id,
@@ -285,8 +285,8 @@ class FlutterReactiveBle {
   /// Use [servicesWithCharacteristicsToDiscover] to scan only for the specific services mentioned in this map,
   /// this can improve the connection speed on iOS since no full service discovery will be executed. On Android
   /// this variable is ignored since partial discovery is not possible.
-  /// The [connectionTimeout] parameter can be used to emit a failure after a certain period in case the connection
-  /// is not established. The pending connection attempt will be cancelled.
+  /// If [connectionTimeout] parameter is supplied and a connection is not established before the Duration expires,
+  /// a TimeoutException will be emit to the onError handler of the returned stream. The pending connection attempt will be cancelled.
   Stream<ConnectionStateUpdate> connectToAdvertisingDevice({
     required String id,
     required List<Uuid> withServices,

--- a/lib/src/reactive_ble.dart
+++ b/lib/src/reactive_ble.dart
@@ -258,10 +258,9 @@ class FlutterReactiveBle {
   /// Use [servicesWithCharacteristicsToDiscover] to scan only for the specific services mentioned in this map,
   /// this can improve the connection speed on iOS since no full service discovery will be executed. On Android
   /// this variable is ignored since partial discovery is not possible.
-  /// If [connectionTimeout] parameter is supplied and a connection is not established before the Duration expires,
-  /// a TimeoutException will be emit to the onError handler of the returned stream. The pending connection attempt will be cancelled.
-  /// On Android when no timeout is specified the `autoConnect` flag is set in the [connectGatt()](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)) call, otherwise it's cleared.```
-
+  /// If [connectionTimeout] parameter is supplied and a connection is not established before [connectionTimeout] expires,
+  /// the pending connection attempt will be cancelled and a [TimeoutException] error will be emitted into the returned stream.
+  /// On Android when no timeout is specified the `autoConnect` flag is set in the [connectGatt()](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)) call, otherwise it is cleared.
   Stream<ConnectionStateUpdate> connectToDevice({
     required String id,
     Map<Uuid, List<Uuid>>? servicesWithCharacteristicsToDiscover,
@@ -285,8 +284,9 @@ class FlutterReactiveBle {
   /// Use [servicesWithCharacteristicsToDiscover] to scan only for the specific services mentioned in this map,
   /// this can improve the connection speed on iOS since no full service discovery will be executed. On Android
   /// this variable is ignored since partial discovery is not possible.
-  /// If [connectionTimeout] parameter is supplied and a connection is not established before the Duration expires,
-  /// a TimeoutException will be emit to the onError handler of the returned stream. The pending connection attempt will be cancelled.
+  /// If [connectionTimeout] parameter is supplied and a connection is not established before [connectionTimeout] expires,
+  /// the pending connection attempt will be cancelled and a [TimeoutException] error will be emitted into the returned stream.
+  /// On Android when no timeout is specified the `autoConnect` flag is set in the [connectGatt()](https://developer.android.com/reference/android/bluetooth/BluetoothDevice#connectGatt(android.content.Context,%20boolean,%20android.bluetooth.BluetoothGattCallback)) call, otherwise it is cleared.
   Stream<ConnectionStateUpdate> connectToAdvertisingDevice({
     required String id,
     required List<Uuid> withServices,


### PR DESCRIPTION
This pull-requests is built on top of #218 to further improve wording in the documentation of `conectToDevice` and `connectToAdvertisingDevice` methods.

Relates to #215.