### PR TITLE
Remove "unnecessary" imports.

### DIFF
--- a/test/connected_device_operation_test.dart
+++ b/test/connected_device_operation_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/connected_device_operation.dart';
+import 'package:flutter_reactive_ble/src/model/result.dart';
 import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/model/write_characteristic_info.dart';
 import 'package:flutter_reactive_ble/src/plugin_controller.dart';

--- a/test/connected_device_operation_test.dart
+++ b/test/connected_device_operation_test.dart
@@ -1,8 +1,13 @@
 import 'dart:async';
 
-import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/connected_device_operation.dart';
+import 'package:flutter_reactive_ble/src/model/characteristic_value.dart';
+import 'package:flutter_reactive_ble/src/model/connection_priority.dart';
+import 'package:flutter_reactive_ble/src/model/connection_state_update.dart';
+import 'package:flutter_reactive_ble/src/model/generic_failure.dart';
+import 'package:flutter_reactive_ble/src/model/qualified_characteristic.dart';
 import 'package:flutter_reactive_ble/src/model/result.dart';
+import 'package:flutter_reactive_ble/src/model/unit.dart';
 import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/model/write_characteristic_info.dart';
 import 'package:flutter_reactive_ble/src/plugin_controller.dart';

--- a/test/connected_device_operation_test.dart
+++ b/test/connected_device_operation_test.dart
@@ -2,10 +2,6 @@ import 'dart:async';
 
 import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/connected_device_operation.dart';
-import 'package:flutter_reactive_ble/src/model/characteristic_value.dart';
-import 'package:flutter_reactive_ble/src/model/qualified_characteristic.dart';
-import 'package:flutter_reactive_ble/src/model/result.dart';
-import 'package:flutter_reactive_ble/src/model/unit.dart';
 import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/model/write_characteristic_info.dart';
 import 'package:flutter_reactive_ble/src/plugin_controller.dart';

--- a/test/converter/args_to_protobuf_converter_test.dart
+++ b/test/converter/args_to_protobuf_converter_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/converter/args_to_protubuf_converter.dart';
 import 'package:flutter_reactive_ble/src/generated/bledata.pbserver.dart' as pb;
-import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/test/converter/args_to_protobuf_converter_test.dart
+++ b/test/converter/args_to_protobuf_converter_test.dart
@@ -1,6 +1,9 @@
-import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/converter/args_to_protubuf_converter.dart';
 import 'package:flutter_reactive_ble/src/generated/bledata.pbserver.dart' as pb;
+import 'package:flutter_reactive_ble/src/model/connection_priority.dart';
+import 'package:flutter_reactive_ble/src/model/qualified_characteristic.dart';
+import 'package:flutter_reactive_ble/src/model/scan_mode.dart';
+import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/test/converter/protobuf_converter_test.dart
+++ b/test/converter/protobuf_converter_test.dart
@@ -4,9 +4,7 @@ import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/converter/protobuf_converter.dart';
 import 'package:flutter_reactive_ble/src/generated/bledata.pb.dart' as pb;
 import 'package:flutter_reactive_ble/src/model/clear_gatt_cache_error.dart';
-import 'package:flutter_reactive_ble/src/model/discovered_service.dart';
 import 'package:flutter_reactive_ble/src/model/unit.dart';
-import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/model/write_characteristic_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/converter/protobuf_converter_test.dart
+++ b/test/converter/protobuf_converter_test.dart
@@ -1,10 +1,18 @@
 import 'dart:typed_data';
 
-import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/converter/protobuf_converter.dart';
 import 'package:flutter_reactive_ble/src/generated/bledata.pb.dart' as pb;
+import 'package:flutter_reactive_ble/src/model/ble_status.dart';
+import 'package:flutter_reactive_ble/src/model/characteristic_value.dart';
 import 'package:flutter_reactive_ble/src/model/clear_gatt_cache_error.dart';
+import 'package:flutter_reactive_ble/src/model/connection_priority.dart';
+import 'package:flutter_reactive_ble/src/model/connection_state_update.dart';
+import 'package:flutter_reactive_ble/src/model/discovered_device.dart';
+import 'package:flutter_reactive_ble/src/model/discovered_service.dart';
+import 'package:flutter_reactive_ble/src/model/generic_failure.dart';
+import 'package:flutter_reactive_ble/src/model/result.dart';
 import 'package:flutter_reactive_ble/src/model/unit.dart';
+import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/model/write_characteristic_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/device_scanner_test.dart
+++ b/test/device_scanner_test.dart
@@ -3,8 +3,6 @@ import 'dart:typed_data';
 
 import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/device_scanner.dart';
-import 'package:flutter_reactive_ble/src/model/discovered_device.dart';
-import 'package:flutter_reactive_ble/src/model/result.dart';
 import 'package:flutter_reactive_ble/src/model/scan_session.dart';
 import 'package:flutter_reactive_ble/src/plugin_controller.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/device_scanner_test.dart
+++ b/test/device_scanner_test.dart
@@ -1,9 +1,13 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:flutter_reactive_ble/flutter_reactive_ble.dart';
 import 'package:flutter_reactive_ble/src/device_scanner.dart';
+import 'package:flutter_reactive_ble/src/model/discovered_device.dart';
+import 'package:flutter_reactive_ble/src/model/generic_failure.dart';
+import 'package:flutter_reactive_ble/src/model/result.dart';
+import 'package:flutter_reactive_ble/src/model/scan_mode.dart';
 import 'package:flutter_reactive_ble/src/model/scan_session.dart';
+import 'package:flutter_reactive_ble/src/model/uuid.dart';
 import 'package:flutter_reactive_ble/src/plugin_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';


### PR DESCRIPTION
In each library where an import is removed, the library uses some elements
provided by the import, BUT there is another import which provides all of the
same elements, and at least one more which the library uses.

In this change, we remove the imports which can be simply removed in favor of
the other already present imports.

See https://github.com/dart-lang/sdk/issues/44569 for more information.