### PR TITLE
Requesting pull request discussion for addition of raw scan record

### DIFF
--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/BleWrapper.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/BleWrapper.kt
@@ -3,7 +3,7 @@ package com.signify.hue.flutterreactiveble.ble
 import com.polidea.rxandroidble2.RxBleConnection
 import java.util.UUID
 
-data class ScanInfo(val deviceId: String, val name: String, val rssi: Int, val serviceData: Map<UUID, ByteArray>, val serviceUuids: List<UUID>, val manufacturerData: ByteArray) {
+data class ScanInfo(val deviceId: String, val name: String, val rssi: Int, val serviceData: Map<UUID, ByteArray>, val serviceUuids: List<UUID>, val manufacturerData: ByteArray, val rawScanRecordData: ByteArray) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -16,6 +16,7 @@ data class ScanInfo(val deviceId: String, val name: String, val rssi: Int, val s
         if (serviceData != other.serviceData) return false
         if (serviceUuids != other.serviceUuids) return false
         if (!manufacturerData.contentEquals(other.manufacturerData)) return false
+        if (!rawScanRecordData.contentEquals(other.rawScanRecordData)) return false
 
         return true
     }
@@ -27,6 +28,7 @@ data class ScanInfo(val deviceId: String, val name: String, val rssi: Int, val s
         result = 31 * result + serviceData.hashCode()
         result = 31 * result + serviceUuids.hashCode()
         result = 31 * result + manufacturerData.contentHashCode()
+        result = 31 * result + rawScanRecordData.contentHashCode()
         return result
     }
 }

--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -86,7 +86,9 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
                     result.rssi,
                     result.scanRecord.serviceData.mapKeys { it.key.uuid },
                     result.scanRecord.serviceUuids?.map { it.uuid } ?: emptyList(),
-                    extractManufacturerData(result.scanRecord.manufacturerSpecificData))
+                    extractManufacturerData(result.scanRecord.manufacturerSpecificData),
+                    result.scanRecord.bytes,
+                )
             }
     }
 

--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -87,8 +87,7 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
                     result.scanRecord.serviceData.mapKeys { it.key.uuid },
                     result.scanRecord.serviceUuids?.map { it.uuid } ?: emptyList(),
                     extractManufacturerData(result.scanRecord.manufacturerSpecificData),
-                    result.scanRecord.bytes,
-                )
+                    result.scanRecord.bytes)
             }
     }
 

--- a/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverter.kt
+++ b/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverter.kt
@@ -38,6 +38,7 @@ class ProtobufMessageConverter {
                     .addAllServiceData(createServiceDataEntry(scanInfo.serviceData))
                     .addAllServiceUuids(createServiceUuids(scanInfo.serviceUuids))
                     .setManufacturerData(ByteString.copyFrom(scanInfo.manufacturerData))
+                    .setRawScanRecordData(ByteString.copyFrom(scanInfo.rawScanRecordData))
                     .build()
 
     fun convertScanErrorInfo(errorMessage: String?): pb.DeviceScanInfo =

--- a/android/src/test/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverterTest.kt
+++ b/android/src/test/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverterTest.kt
@@ -93,6 +93,15 @@ class ProtobufMessageConverterTest {
 
             assertThat(result.manufacturerData.toByteArray()).isEqualTo(scanInfo.manufacturerData)
         }
+
+        @Test
+        fun `converts raw scan record data into message raw scan record data`() {
+            val scanInfo = createScanInfo()
+
+            val result = protobufConverter.convertScanInfo(scanInfo)
+
+            assertThat(result.rawScanRecordData.toByteArray()).isEqualTo(scanInfo.rawScanRecordData)
+        }
     }
 
     @Nested
@@ -194,11 +203,13 @@ class ProtobufMessageConverterTest {
 
         val manufacturerData = "123".toByteArray()
 
+        val rawScanRecord = "TEST_SCAN_RECORD".toByteArray()
+
         return ScanInfo(
                 deviceId = macAdress, name = deviceName,
                 rssi = rssi, serviceData = serviceData, manufacturerData = manufacturerData,
                 serviceUuids = listOf(serviceUuid),
-        )
+                rawScanRecordData = rawScanRecord)
     }
 
     private fun createCharacteristicRequest(deviceId: String, serviceUuid: UUID): pb.ReadCharacteristicRequest {

--- a/lib/src/converter/protobuf_converter.dart
+++ b/lib/src/converter/protobuf_converter.dart
@@ -73,6 +73,7 @@ class ProtobufConverterImpl implements ProtobufConverter {
           serviceUuids: serviceUuids,
           manufacturerData: Uint8List.fromList(message.manufacturerData),
           rssi: message.rssi,
+          rawScanRecordData: Uint8List.fromList(message.rawScanRecordData),
         ),
         failure: genericFailureFrom(
             hasFailure: message.hasFailure(),

--- a/lib/src/generated/bledata.pb.dart
+++ b/lib/src/generated/bledata.pb.dart
@@ -10,26 +10,12 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class ScanForDevicesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ScanForDevicesRequest',
-      createEmptyInstance: create)
-    ..pc<Uuid>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'serviceUuids',
-        $pb.PbFieldType.PM,
-        protoName: 'serviceUuids',
-        subBuilder: Uuid.create)
-    ..a<$core.int>(
-        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'scanMode', $pb.PbFieldType.O3,
-        protoName: 'scanMode')
-    ..aOB(
-        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requireLocationServicesEnabled',
-        protoName: 'requireLocationServicesEnabled')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ScanForDevicesRequest', createEmptyInstance: create)
+    ..pc<Uuid>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuids', $pb.PbFieldType.PM, protoName: 'serviceUuids', subBuilder: Uuid.create)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'scanMode', $pb.PbFieldType.O3, protoName: 'scanMode')
+    ..aOB(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'requireLocationServicesEnabled', protoName: 'requireLocationServicesEnabled')
+    ..hasRequiredFields = false
+  ;
 
   ScanForDevicesRequest._() : super();
   factory ScanForDevicesRequest({
@@ -49,33 +35,25 @@ class ScanForDevicesRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ScanForDevicesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ScanForDevicesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ScanForDevicesRequest clone() =>
-      ScanForDevicesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ScanForDevicesRequest copyWith(
-          void Function(ScanForDevicesRequest) updates) =>
-      super.copyWith((message) => updates(message as ScanForDevicesRequest))
-          as ScanForDevicesRequest; // ignore: deprecated_member_use
+  factory ScanForDevicesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ScanForDevicesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ScanForDevicesRequest clone() => ScanForDevicesRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ScanForDevicesRequest copyWith(void Function(ScanForDevicesRequest) updates) => super.copyWith((message) => updates(message as ScanForDevicesRequest)) as ScanForDevicesRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ScanForDevicesRequest create() => ScanForDevicesRequest._();
   ScanForDevicesRequest createEmptyInstance() => create();
-  static $pb.PbList<ScanForDevicesRequest> createRepeated() =>
-      $pb.PbList<ScanForDevicesRequest>();
+  static $pb.PbList<ScanForDevicesRequest> createRepeated() => $pb.PbList<ScanForDevicesRequest>();
   @$core.pragma('dart2js:noInline')
-  static ScanForDevicesRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ScanForDevicesRequest>(create);
+  static ScanForDevicesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ScanForDevicesRequest>(create);
   static ScanForDevicesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -84,10 +62,7 @@ class ScanForDevicesRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get scanMode => $_getIZ(1);
   @$pb.TagNumber(2)
-  set scanMode($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set scanMode($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasScanMode() => $_has(1);
   @$pb.TagNumber(2)
@@ -96,10 +71,7 @@ class ScanForDevicesRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.bool get requireLocationServicesEnabled => $_getBF(2);
   @$pb.TagNumber(3)
-  set requireLocationServicesEnabled($core.bool v) {
-    $_setBool(2, v);
-  }
-
+  set requireLocationServicesEnabled($core.bool v) { $_setBool(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasRequireLocationServicesEnabled() => $_has(2);
   @$pb.TagNumber(3)
@@ -107,35 +79,17 @@ class ScanForDevicesRequest extends $pb.GeneratedMessage {
 }
 
 class DeviceScanInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DeviceScanInfo',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'name')
-    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure',
-        subBuilder: GenericFailure.create)
-    ..pc<ServiceDataEntry>(
-        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceData', $pb.PbFieldType.PM,
-        protoName: 'serviceData', subBuilder: ServiceDataEntry.create)
-    ..a<$core.int>(
-        5,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'rssi',
-        $pb.PbFieldType.O3)
-    ..a<$core.List<$core.int>>(
-        6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'manufacturerData', $pb.PbFieldType.OY,
-        protoName: 'manufacturerData')
-    ..pc<Uuid>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuids', $pb.PbFieldType.PM,
-        protoName: 'serviceUuids', subBuilder: Uuid.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DeviceScanInfo', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..pc<ServiceDataEntry>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceData', $pb.PbFieldType.PM, protoName: 'serviceData', subBuilder: ServiceDataEntry.create)
+    ..a<$core.int>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rssi', $pb.PbFieldType.O3)
+    ..a<$core.List<$core.int>>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'manufacturerData', $pb.PbFieldType.OY, protoName: 'manufacturerData')
+    ..pc<Uuid>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuids', $pb.PbFieldType.PM, protoName: 'serviceUuids', subBuilder: Uuid.create)
+    ..a<$core.List<$core.int>>(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'rawScanRecordData', $pb.PbFieldType.OY, protoName: 'rawScanRecordData')
+    ..hasRequiredFields = false
+  ;
 
   DeviceScanInfo._() : super();
   factory DeviceScanInfo({
@@ -146,6 +100,7 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
     $core.int? rssi,
     $core.List<$core.int>? manufacturerData,
     $core.Iterable<Uuid>? serviceUuids,
+    $core.List<$core.int>? rawScanRecordData,
   }) {
     final _result = create();
     if (id != null) {
@@ -169,42 +124,36 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
     if (serviceUuids != null) {
       _result.serviceUuids.addAll(serviceUuids);
     }
+    if (rawScanRecordData != null) {
+      _result.rawScanRecordData = rawScanRecordData;
+    }
     return _result;
   }
-  factory DeviceScanInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeviceScanInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory DeviceScanInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeviceScanInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeviceScanInfo clone() => DeviceScanInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeviceScanInfo copyWith(void Function(DeviceScanInfo) updates) =>
-      super.copyWith((message) => updates(message as DeviceScanInfo))
-          as DeviceScanInfo; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeviceScanInfo copyWith(void Function(DeviceScanInfo) updates) => super.copyWith((message) => updates(message as DeviceScanInfo)) as DeviceScanInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DeviceScanInfo create() => DeviceScanInfo._();
   DeviceScanInfo createEmptyInstance() => create();
-  static $pb.PbList<DeviceScanInfo> createRepeated() =>
-      $pb.PbList<DeviceScanInfo>();
+  static $pb.PbList<DeviceScanInfo> createRepeated() => $pb.PbList<DeviceScanInfo>();
   @$core.pragma('dart2js:noInline')
-  static DeviceScanInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DeviceScanInfo>(create);
+  static DeviceScanInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeviceScanInfo>(create);
   static DeviceScanInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -213,10 +162,7 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get name => $_getSZ(1);
   @$pb.TagNumber(2)
-  set name($core.String v) {
-    $_setString(1, v);
-  }
-
+  set name($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasName() => $_has(1);
   @$pb.TagNumber(2)
@@ -225,10 +171,7 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GenericFailure get failure => $_getN(2);
   @$pb.TagNumber(3)
-  set failure(GenericFailure v) {
-    setField(3, v);
-  }
-
+  set failure(GenericFailure v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFailure() => $_has(2);
   @$pb.TagNumber(3)
@@ -242,10 +185,7 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.int get rssi => $_getIZ(4);
   @$pb.TagNumber(5)
-  set rssi($core.int v) {
-    $_setSignedInt32(4, v);
-  }
-
+  set rssi($core.int v) { $_setSignedInt32(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasRssi() => $_has(4);
   @$pb.TagNumber(5)
@@ -254,10 +194,7 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.List<$core.int> get manufacturerData => $_getN(5);
   @$pb.TagNumber(6)
-  set manufacturerData($core.List<$core.int> v) {
-    $_setBytes(5, v);
-  }
-
+  set manufacturerData($core.List<$core.int> v) { $_setBytes(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasManufacturerData() => $_has(5);
   @$pb.TagNumber(6)
@@ -265,30 +202,24 @@ class DeviceScanInfo extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(7)
   $core.List<Uuid> get serviceUuids => $_getList(6);
+
+  @$pb.TagNumber(8)
+  $core.List<$core.int> get rawScanRecordData => $_getN(7);
+  @$pb.TagNumber(8)
+  set rawScanRecordData($core.List<$core.int> v) { $_setBytes(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasRawScanRecordData() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearRawScanRecordData() => clearField(8);
 }
 
 class ConnectToDeviceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ConnectToDeviceRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId',
-        protoName: 'deviceId')
-    ..aOM<ServicesWithCharacteristics>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'servicesWithCharacteristicsToDiscover',
-        protoName: 'servicesWithCharacteristicsToDiscover',
-        subBuilder: ServicesWithCharacteristics.create)
-    ..a<$core.int>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeoutInMs',
-        $pb.PbFieldType.O3,
-        protoName: 'timeoutInMs')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConnectToDeviceRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..aOM<ServicesWithCharacteristics>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'servicesWithCharacteristicsToDiscover', protoName: 'servicesWithCharacteristicsToDiscover', subBuilder: ServicesWithCharacteristics.create)
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'timeoutInMs', $pb.PbFieldType.O3, protoName: 'timeoutInMs')
+    ..hasRequiredFields = false
+  ;
 
   ConnectToDeviceRequest._() : super();
   factory ConnectToDeviceRequest({
@@ -301,78 +232,58 @@ class ConnectToDeviceRequest extends $pb.GeneratedMessage {
       _result.deviceId = deviceId;
     }
     if (servicesWithCharacteristicsToDiscover != null) {
-      _result.servicesWithCharacteristicsToDiscover =
-          servicesWithCharacteristicsToDiscover;
+      _result.servicesWithCharacteristicsToDiscover = servicesWithCharacteristicsToDiscover;
     }
     if (timeoutInMs != null) {
       _result.timeoutInMs = timeoutInMs;
     }
     return _result;
   }
-  factory ConnectToDeviceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConnectToDeviceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ConnectToDeviceRequest clone() =>
-      ConnectToDeviceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConnectToDeviceRequest copyWith(
-          void Function(ConnectToDeviceRequest) updates) =>
-      super.copyWith((message) => updates(message as ConnectToDeviceRequest))
-          as ConnectToDeviceRequest; // ignore: deprecated_member_use
+  factory ConnectToDeviceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConnectToDeviceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ConnectToDeviceRequest clone() => ConnectToDeviceRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConnectToDeviceRequest copyWith(void Function(ConnectToDeviceRequest) updates) => super.copyWith((message) => updates(message as ConnectToDeviceRequest)) as ConnectToDeviceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ConnectToDeviceRequest create() => ConnectToDeviceRequest._();
   ConnectToDeviceRequest createEmptyInstance() => create();
-  static $pb.PbList<ConnectToDeviceRequest> createRepeated() =>
-      $pb.PbList<ConnectToDeviceRequest>();
+  static $pb.PbList<ConnectToDeviceRequest> createRepeated() => $pb.PbList<ConnectToDeviceRequest>();
   @$core.pragma('dart2js:noInline')
-  static ConnectToDeviceRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ConnectToDeviceRequest>(create);
+  static ConnectToDeviceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ConnectToDeviceRequest>(create);
   static ConnectToDeviceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
   void clearDeviceId() => clearField(1);
 
   @$pb.TagNumber(2)
-  ServicesWithCharacteristics get servicesWithCharacteristicsToDiscover =>
-      $_getN(1);
+  ServicesWithCharacteristics get servicesWithCharacteristicsToDiscover => $_getN(1);
   @$pb.TagNumber(2)
-  set servicesWithCharacteristicsToDiscover(ServicesWithCharacteristics v) {
-    setField(2, v);
-  }
-
+  set servicesWithCharacteristicsToDiscover(ServicesWithCharacteristics v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasServicesWithCharacteristicsToDiscover() => $_has(1);
   @$pb.TagNumber(2)
   void clearServicesWithCharacteristicsToDiscover() => clearField(2);
   @$pb.TagNumber(2)
-  ServicesWithCharacteristics ensureServicesWithCharacteristicsToDiscover() =>
-      $_ensure(1);
+  ServicesWithCharacteristics ensureServicesWithCharacteristicsToDiscover() => $_ensure(1);
 
   @$pb.TagNumber(3)
   $core.int get timeoutInMs => $_getIZ(2);
   @$pb.TagNumber(3)
-  set timeoutInMs($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set timeoutInMs($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasTimeoutInMs() => $_has(2);
   @$pb.TagNumber(3)
@@ -380,30 +291,12 @@ class ConnectToDeviceRequest extends $pb.GeneratedMessage {
 }
 
 class DeviceInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DeviceInfo',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'id')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'connectionState',
-        $pb.PbFieldType.O3,
-        protoName: 'connectionState')
-    ..aOM<GenericFailure>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DeviceInfo', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'id')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'connectionState', $pb.PbFieldType.O3, protoName: 'connectionState')
+    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   DeviceInfo._() : super();
   factory DeviceInfo({
@@ -423,39 +316,31 @@ class DeviceInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DeviceInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DeviceInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory DeviceInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DeviceInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DeviceInfo clone() => DeviceInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DeviceInfo copyWith(void Function(DeviceInfo) updates) =>
-      super.copyWith((message) => updates(message as DeviceInfo))
-          as DeviceInfo; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DeviceInfo copyWith(void Function(DeviceInfo) updates) => super.copyWith((message) => updates(message as DeviceInfo)) as DeviceInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DeviceInfo create() => DeviceInfo._();
   DeviceInfo createEmptyInstance() => create();
   static $pb.PbList<DeviceInfo> createRepeated() => $pb.PbList<DeviceInfo>();
   @$core.pragma('dart2js:noInline')
-  static DeviceInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DeviceInfo>(create);
+  static DeviceInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DeviceInfo>(create);
   static DeviceInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get id => $_getSZ(0);
   @$pb.TagNumber(1)
-  set id($core.String v) {
-    $_setString(0, v);
-  }
-
+  set id($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasId() => $_has(0);
   @$pb.TagNumber(1)
@@ -464,10 +349,7 @@ class DeviceInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get connectionState => $_getIZ(1);
   @$pb.TagNumber(2)
-  set connectionState($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set connectionState($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasConnectionState() => $_has(1);
   @$pb.TagNumber(2)
@@ -476,10 +358,7 @@ class DeviceInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GenericFailure get failure => $_getN(2);
   @$pb.TagNumber(3)
-  set failure(GenericFailure v) {
-    setField(3, v);
-  }
-
+  set failure(GenericFailure v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFailure() => $_has(2);
   @$pb.TagNumber(3)
@@ -489,18 +368,10 @@ class DeviceInfo extends $pb.GeneratedMessage {
 }
 
 class DisconnectFromDeviceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DisconnectFromDeviceRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DisconnectFromDeviceRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..hasRequiredFields = false
+  ;
 
   DisconnectFromDeviceRequest._() : super();
   factory DisconnectFromDeviceRequest({
@@ -512,44 +383,31 @@ class DisconnectFromDeviceRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DisconnectFromDeviceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DisconnectFromDeviceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DisconnectFromDeviceRequest clone() =>
-      DisconnectFromDeviceRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DisconnectFromDeviceRequest copyWith(
-          void Function(DisconnectFromDeviceRequest) updates) =>
-      super.copyWith(
-              (message) => updates(message as DisconnectFromDeviceRequest))
-          as DisconnectFromDeviceRequest; // ignore: deprecated_member_use
+  factory DisconnectFromDeviceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DisconnectFromDeviceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DisconnectFromDeviceRequest clone() => DisconnectFromDeviceRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DisconnectFromDeviceRequest copyWith(void Function(DisconnectFromDeviceRequest) updates) => super.copyWith((message) => updates(message as DisconnectFromDeviceRequest)) as DisconnectFromDeviceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static DisconnectFromDeviceRequest create() =>
-      DisconnectFromDeviceRequest._();
+  static DisconnectFromDeviceRequest create() => DisconnectFromDeviceRequest._();
   DisconnectFromDeviceRequest createEmptyInstance() => create();
-  static $pb.PbList<DisconnectFromDeviceRequest> createRepeated() =>
-      $pb.PbList<DisconnectFromDeviceRequest>();
+  static $pb.PbList<DisconnectFromDeviceRequest> createRepeated() => $pb.PbList<DisconnectFromDeviceRequest>();
   @$core.pragma('dart2js:noInline')
-  static DisconnectFromDeviceRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DisconnectFromDeviceRequest>(create);
+  static DisconnectFromDeviceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DisconnectFromDeviceRequest>(create);
   static DisconnectFromDeviceRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -557,18 +415,10 @@ class DisconnectFromDeviceRequest extends $pb.GeneratedMessage {
 }
 
 class ClearGattCacheRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ClearGattCacheRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ClearGattCacheRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..hasRequiredFields = false
+  ;
 
   ClearGattCacheRequest._() : super();
   factory ClearGattCacheRequest({
@@ -580,42 +430,31 @@ class ClearGattCacheRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ClearGattCacheRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ClearGattCacheRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ClearGattCacheRequest clone() =>
-      ClearGattCacheRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ClearGattCacheRequest copyWith(
-          void Function(ClearGattCacheRequest) updates) =>
-      super.copyWith((message) => updates(message as ClearGattCacheRequest))
-          as ClearGattCacheRequest; // ignore: deprecated_member_use
+  factory ClearGattCacheRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ClearGattCacheRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ClearGattCacheRequest clone() => ClearGattCacheRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ClearGattCacheRequest copyWith(void Function(ClearGattCacheRequest) updates) => super.copyWith((message) => updates(message as ClearGattCacheRequest)) as ClearGattCacheRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ClearGattCacheRequest create() => ClearGattCacheRequest._();
   ClearGattCacheRequest createEmptyInstance() => create();
-  static $pb.PbList<ClearGattCacheRequest> createRepeated() =>
-      $pb.PbList<ClearGattCacheRequest>();
+  static $pb.PbList<ClearGattCacheRequest> createRepeated() => $pb.PbList<ClearGattCacheRequest>();
   @$core.pragma('dart2js:noInline')
-  static ClearGattCacheRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ClearGattCacheRequest>(create);
+  static ClearGattCacheRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClearGattCacheRequest>(create);
   static ClearGattCacheRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -623,18 +462,10 @@ class ClearGattCacheRequest extends $pb.GeneratedMessage {
 }
 
 class ClearGattCacheInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ClearGattCacheInfo',
-      createEmptyInstance: create)
-    ..aOM<GenericFailure>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ClearGattCacheInfo', createEmptyInstance: create)
+    ..aOM<GenericFailure>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   ClearGattCacheInfo._() : super();
   factory ClearGattCacheInfo({
@@ -646,40 +477,31 @@ class ClearGattCacheInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ClearGattCacheInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ClearGattCacheInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory ClearGattCacheInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ClearGattCacheInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ClearGattCacheInfo clone() => ClearGattCacheInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ClearGattCacheInfo copyWith(void Function(ClearGattCacheInfo) updates) =>
-      super.copyWith((message) => updates(message as ClearGattCacheInfo))
-          as ClearGattCacheInfo; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ClearGattCacheInfo copyWith(void Function(ClearGattCacheInfo) updates) => super.copyWith((message) => updates(message as ClearGattCacheInfo)) as ClearGattCacheInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ClearGattCacheInfo create() => ClearGattCacheInfo._();
   ClearGattCacheInfo createEmptyInstance() => create();
-  static $pb.PbList<ClearGattCacheInfo> createRepeated() =>
-      $pb.PbList<ClearGattCacheInfo>();
+  static $pb.PbList<ClearGattCacheInfo> createRepeated() => $pb.PbList<ClearGattCacheInfo>();
   @$core.pragma('dart2js:noInline')
-  static ClearGattCacheInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ClearGattCacheInfo>(create);
+  static ClearGattCacheInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ClearGattCacheInfo>(create);
   static ClearGattCacheInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   GenericFailure get failure => $_getN(0);
   @$pb.TagNumber(1)
-  set failure(GenericFailure v) {
-    setField(1, v);
-  }
-
+  set failure(GenericFailure v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasFailure() => $_has(0);
   @$pb.TagNumber(1)
@@ -689,18 +511,10 @@ class ClearGattCacheInfo extends $pb.GeneratedMessage {
 }
 
 class NotifyCharacteristicRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'NotifyCharacteristicRequest',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NotifyCharacteristicRequest', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..hasRequiredFields = false
+  ;
 
   NotifyCharacteristicRequest._() : super();
   factory NotifyCharacteristicRequest({
@@ -712,44 +526,31 @@ class NotifyCharacteristicRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NotifyCharacteristicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NotifyCharacteristicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  NotifyCharacteristicRequest clone() =>
-      NotifyCharacteristicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  NotifyCharacteristicRequest copyWith(
-          void Function(NotifyCharacteristicRequest) updates) =>
-      super.copyWith(
-              (message) => updates(message as NotifyCharacteristicRequest))
-          as NotifyCharacteristicRequest; // ignore: deprecated_member_use
+  factory NotifyCharacteristicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NotifyCharacteristicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NotifyCharacteristicRequest clone() => NotifyCharacteristicRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NotifyCharacteristicRequest copyWith(void Function(NotifyCharacteristicRequest) updates) => super.copyWith((message) => updates(message as NotifyCharacteristicRequest)) as NotifyCharacteristicRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static NotifyCharacteristicRequest create() =>
-      NotifyCharacteristicRequest._();
+  static NotifyCharacteristicRequest create() => NotifyCharacteristicRequest._();
   NotifyCharacteristicRequest createEmptyInstance() => create();
-  static $pb.PbList<NotifyCharacteristicRequest> createRepeated() =>
-      $pb.PbList<NotifyCharacteristicRequest>();
+  static $pb.PbList<NotifyCharacteristicRequest> createRepeated() => $pb.PbList<NotifyCharacteristicRequest>();
   @$core.pragma('dart2js:noInline')
-  static NotifyCharacteristicRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<NotifyCharacteristicRequest>(create);
+  static NotifyCharacteristicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotifyCharacteristicRequest>(create);
   static NotifyCharacteristicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -759,18 +560,10 @@ class NotifyCharacteristicRequest extends $pb.GeneratedMessage {
 }
 
 class NotifyNoMoreCharacteristicRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'NotifyNoMoreCharacteristicRequest',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NotifyNoMoreCharacteristicRequest', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..hasRequiredFields = false
+  ;
 
   NotifyNoMoreCharacteristicRequest._() : super();
   factory NotifyNoMoreCharacteristicRequest({
@@ -782,45 +575,31 @@ class NotifyNoMoreCharacteristicRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NotifyNoMoreCharacteristicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NotifyNoMoreCharacteristicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  NotifyNoMoreCharacteristicRequest clone() =>
-      NotifyNoMoreCharacteristicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  NotifyNoMoreCharacteristicRequest copyWith(
-          void Function(NotifyNoMoreCharacteristicRequest) updates) =>
-      super.copyWith((message) =>
-              updates(message as NotifyNoMoreCharacteristicRequest))
-          as NotifyNoMoreCharacteristicRequest; // ignore: deprecated_member_use
+  factory NotifyNoMoreCharacteristicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NotifyNoMoreCharacteristicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NotifyNoMoreCharacteristicRequest clone() => NotifyNoMoreCharacteristicRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NotifyNoMoreCharacteristicRequest copyWith(void Function(NotifyNoMoreCharacteristicRequest) updates) => super.copyWith((message) => updates(message as NotifyNoMoreCharacteristicRequest)) as NotifyNoMoreCharacteristicRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static NotifyNoMoreCharacteristicRequest create() =>
-      NotifyNoMoreCharacteristicRequest._();
+  static NotifyNoMoreCharacteristicRequest create() => NotifyNoMoreCharacteristicRequest._();
   NotifyNoMoreCharacteristicRequest createEmptyInstance() => create();
-  static $pb.PbList<NotifyNoMoreCharacteristicRequest> createRepeated() =>
-      $pb.PbList<NotifyNoMoreCharacteristicRequest>();
+  static $pb.PbList<NotifyNoMoreCharacteristicRequest> createRepeated() => $pb.PbList<NotifyNoMoreCharacteristicRequest>();
   @$core.pragma('dart2js:noInline')
-  static NotifyNoMoreCharacteristicRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<NotifyNoMoreCharacteristicRequest>(
-          create);
+  static NotifyNoMoreCharacteristicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NotifyNoMoreCharacteristicRequest>(create);
   static NotifyNoMoreCharacteristicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -830,18 +609,10 @@ class NotifyNoMoreCharacteristicRequest extends $pb.GeneratedMessage {
 }
 
 class ReadCharacteristicRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ReadCharacteristicRequest',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ReadCharacteristicRequest', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..hasRequiredFields = false
+  ;
 
   ReadCharacteristicRequest._() : super();
   factory ReadCharacteristicRequest({
@@ -853,42 +624,31 @@ class ReadCharacteristicRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ReadCharacteristicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ReadCharacteristicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ReadCharacteristicRequest clone() =>
-      ReadCharacteristicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ReadCharacteristicRequest copyWith(
-          void Function(ReadCharacteristicRequest) updates) =>
-      super.copyWith((message) => updates(message as ReadCharacteristicRequest))
-          as ReadCharacteristicRequest; // ignore: deprecated_member_use
+  factory ReadCharacteristicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ReadCharacteristicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ReadCharacteristicRequest clone() => ReadCharacteristicRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ReadCharacteristicRequest copyWith(void Function(ReadCharacteristicRequest) updates) => super.copyWith((message) => updates(message as ReadCharacteristicRequest)) as ReadCharacteristicRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ReadCharacteristicRequest create() => ReadCharacteristicRequest._();
   ReadCharacteristicRequest createEmptyInstance() => create();
-  static $pb.PbList<ReadCharacteristicRequest> createRepeated() =>
-      $pb.PbList<ReadCharacteristicRequest>();
+  static $pb.PbList<ReadCharacteristicRequest> createRepeated() => $pb.PbList<ReadCharacteristicRequest>();
   @$core.pragma('dart2js:noInline')
-  static ReadCharacteristicRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ReadCharacteristicRequest>(create);
+  static ReadCharacteristicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ReadCharacteristicRequest>(create);
   static ReadCharacteristicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -898,27 +658,12 @@ class ReadCharacteristicRequest extends $pb.GeneratedMessage {
 }
 
 class CharacteristicValueInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CharacteristicValueInfo',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..a<$core.List<$core.int>>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OY)
-    ..aOM<GenericFailure>(3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CharacteristicValueInfo', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
+    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   CharacteristicValueInfo._() : super();
   factory CharacteristicValueInfo({
@@ -938,42 +683,31 @@ class CharacteristicValueInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CharacteristicValueInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CharacteristicValueInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  CharacteristicValueInfo clone() =>
-      CharacteristicValueInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CharacteristicValueInfo copyWith(
-          void Function(CharacteristicValueInfo) updates) =>
-      super.copyWith((message) => updates(message as CharacteristicValueInfo))
-          as CharacteristicValueInfo; // ignore: deprecated_member_use
+  factory CharacteristicValueInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CharacteristicValueInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CharacteristicValueInfo clone() => CharacteristicValueInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CharacteristicValueInfo copyWith(void Function(CharacteristicValueInfo) updates) => super.copyWith((message) => updates(message as CharacteristicValueInfo)) as CharacteristicValueInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CharacteristicValueInfo create() => CharacteristicValueInfo._();
   CharacteristicValueInfo createEmptyInstance() => create();
-  static $pb.PbList<CharacteristicValueInfo> createRepeated() =>
-      $pb.PbList<CharacteristicValueInfo>();
+  static $pb.PbList<CharacteristicValueInfo> createRepeated() => $pb.PbList<CharacteristicValueInfo>();
   @$core.pragma('dart2js:noInline')
-  static CharacteristicValueInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CharacteristicValueInfo>(create);
+  static CharacteristicValueInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CharacteristicValueInfo>(create);
   static CharacteristicValueInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -984,10 +718,7 @@ class CharacteristicValueInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get value => $_getN(1);
   @$pb.TagNumber(2)
-  set value($core.List<$core.int> v) {
-    $_setBytes(1, v);
-  }
-
+  set value($core.List<$core.int> v) { $_setBytes(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -996,10 +727,7 @@ class CharacteristicValueInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GenericFailure get failure => $_getN(2);
   @$pb.TagNumber(3)
-  set failure(GenericFailure v) {
-    setField(3, v);
-  }
-
+  set failure(GenericFailure v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFailure() => $_has(2);
   @$pb.TagNumber(3)
@@ -1009,24 +737,11 @@ class CharacteristicValueInfo extends $pb.GeneratedMessage {
 }
 
 class WriteCharacteristicRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteCharacteristicRequest',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..a<$core.List<$core.int>>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'value',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'WriteCharacteristicRequest', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
 
   WriteCharacteristicRequest._() : super();
   factory WriteCharacteristicRequest({
@@ -1042,43 +757,31 @@ class WriteCharacteristicRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory WriteCharacteristicRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteCharacteristicRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteCharacteristicRequest clone() =>
-      WriteCharacteristicRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteCharacteristicRequest copyWith(
-          void Function(WriteCharacteristicRequest) updates) =>
-      super.copyWith(
-              (message) => updates(message as WriteCharacteristicRequest))
-          as WriteCharacteristicRequest; // ignore: deprecated_member_use
+  factory WriteCharacteristicRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteCharacteristicRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WriteCharacteristicRequest clone() => WriteCharacteristicRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteCharacteristicRequest copyWith(void Function(WriteCharacteristicRequest) updates) => super.copyWith((message) => updates(message as WriteCharacteristicRequest)) as WriteCharacteristicRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static WriteCharacteristicRequest create() => WriteCharacteristicRequest._();
   WriteCharacteristicRequest createEmptyInstance() => create();
-  static $pb.PbList<WriteCharacteristicRequest> createRepeated() =>
-      $pb.PbList<WriteCharacteristicRequest>();
+  static $pb.PbList<WriteCharacteristicRequest> createRepeated() => $pb.PbList<WriteCharacteristicRequest>();
   @$core.pragma('dart2js:noInline')
-  static WriteCharacteristicRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<WriteCharacteristicRequest>(create);
+  static WriteCharacteristicRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteCharacteristicRequest>(create);
   static WriteCharacteristicRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -1089,10 +792,7 @@ class WriteCharacteristicRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get value => $_getN(1);
   @$pb.TagNumber(2)
-  set value($core.List<$core.int> v) {
-    $_setBytes(1, v);
-  }
-
+  set value($core.List<$core.int> v) { $_setBytes(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasValue() => $_has(1);
   @$pb.TagNumber(2)
@@ -1100,24 +800,11 @@ class WriteCharacteristicRequest extends $pb.GeneratedMessage {
 }
 
 class WriteCharacteristicInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'WriteCharacteristicInfo',
-      createEmptyInstance: create)
-    ..aOM<CharacteristicAddress>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristic',
-        subBuilder: CharacteristicAddress.create)
-    ..aOM<GenericFailure>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'WriteCharacteristicInfo', createEmptyInstance: create)
+    ..aOM<CharacteristicAddress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristic', subBuilder: CharacteristicAddress.create)
+    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   WriteCharacteristicInfo._() : super();
   factory WriteCharacteristicInfo({
@@ -1133,42 +820,31 @@ class WriteCharacteristicInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory WriteCharacteristicInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory WriteCharacteristicInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  WriteCharacteristicInfo clone() =>
-      WriteCharacteristicInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  WriteCharacteristicInfo copyWith(
-          void Function(WriteCharacteristicInfo) updates) =>
-      super.copyWith((message) => updates(message as WriteCharacteristicInfo))
-          as WriteCharacteristicInfo; // ignore: deprecated_member_use
+  factory WriteCharacteristicInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory WriteCharacteristicInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  WriteCharacteristicInfo clone() => WriteCharacteristicInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  WriteCharacteristicInfo copyWith(void Function(WriteCharacteristicInfo) updates) => super.copyWith((message) => updates(message as WriteCharacteristicInfo)) as WriteCharacteristicInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static WriteCharacteristicInfo create() => WriteCharacteristicInfo._();
   WriteCharacteristicInfo createEmptyInstance() => create();
-  static $pb.PbList<WriteCharacteristicInfo> createRepeated() =>
-      $pb.PbList<WriteCharacteristicInfo>();
+  static $pb.PbList<WriteCharacteristicInfo> createRepeated() => $pb.PbList<WriteCharacteristicInfo>();
   @$core.pragma('dart2js:noInline')
-  static WriteCharacteristicInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<WriteCharacteristicInfo>(create);
+  static WriteCharacteristicInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<WriteCharacteristicInfo>(create);
   static WriteCharacteristicInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   CharacteristicAddress get characteristic => $_getN(0);
   @$pb.TagNumber(1)
-  set characteristic(CharacteristicAddress v) {
-    setField(1, v);
-  }
-
+  set characteristic(CharacteristicAddress v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasCharacteristic() => $_has(0);
   @$pb.TagNumber(1)
@@ -1179,10 +855,7 @@ class WriteCharacteristicInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GenericFailure get failure => $_getN(1);
   @$pb.TagNumber(3)
-  set failure(GenericFailure v) {
-    setField(3, v);
-  }
-
+  set failure(GenericFailure v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFailure() => $_has(1);
   @$pb.TagNumber(3)
@@ -1192,25 +865,11 @@ class WriteCharacteristicInfo extends $pb.GeneratedMessage {
 }
 
 class NegotiateMtuRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'NegotiateMtuRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'mtuSize',
-        $pb.PbFieldType.O3,
-        protoName: 'mtuSize')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NegotiateMtuRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mtuSize', $pb.PbFieldType.O3, protoName: 'mtuSize')
+    ..hasRequiredFields = false
+  ;
 
   NegotiateMtuRequest._() : super();
   factory NegotiateMtuRequest({
@@ -1226,40 +885,31 @@ class NegotiateMtuRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NegotiateMtuRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NegotiateMtuRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory NegotiateMtuRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NegotiateMtuRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   NegotiateMtuRequest clone() => NegotiateMtuRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  NegotiateMtuRequest copyWith(void Function(NegotiateMtuRequest) updates) =>
-      super.copyWith((message) => updates(message as NegotiateMtuRequest))
-          as NegotiateMtuRequest; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NegotiateMtuRequest copyWith(void Function(NegotiateMtuRequest) updates) => super.copyWith((message) => updates(message as NegotiateMtuRequest)) as NegotiateMtuRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static NegotiateMtuRequest create() => NegotiateMtuRequest._();
   NegotiateMtuRequest createEmptyInstance() => create();
-  static $pb.PbList<NegotiateMtuRequest> createRepeated() =>
-      $pb.PbList<NegotiateMtuRequest>();
+  static $pb.PbList<NegotiateMtuRequest> createRepeated() => $pb.PbList<NegotiateMtuRequest>();
   @$core.pragma('dart2js:noInline')
-  static NegotiateMtuRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<NegotiateMtuRequest>(create);
+  static NegotiateMtuRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NegotiateMtuRequest>(create);
   static NegotiateMtuRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1268,10 +918,7 @@ class NegotiateMtuRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get mtuSize => $_getIZ(1);
   @$pb.TagNumber(2)
-  set mtuSize($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set mtuSize($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMtuSize() => $_has(1);
   @$pb.TagNumber(2)
@@ -1279,25 +926,12 @@ class NegotiateMtuRequest extends $pb.GeneratedMessage {
 }
 
 class NegotiateMtuInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'NegotiateMtuInfo',
-      createEmptyInstance: create)
-    ..aOS(
-        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId',
-        protoName: 'deviceId')
-    ..a<$core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'mtuSize',
-        $pb.PbFieldType.O3,
-        protoName: 'mtuSize')
-    ..aOM<GenericFailure>(3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NegotiateMtuInfo', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mtuSize', $pb.PbFieldType.O3, protoName: 'mtuSize')
+    ..aOM<GenericFailure>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   NegotiateMtuInfo._() : super();
   factory NegotiateMtuInfo({
@@ -1317,40 +951,31 @@ class NegotiateMtuInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NegotiateMtuInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory NegotiateMtuInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory NegotiateMtuInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NegotiateMtuInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   NegotiateMtuInfo clone() => NegotiateMtuInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  NegotiateMtuInfo copyWith(void Function(NegotiateMtuInfo) updates) =>
-      super.copyWith((message) => updates(message as NegotiateMtuInfo))
-          as NegotiateMtuInfo; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NegotiateMtuInfo copyWith(void Function(NegotiateMtuInfo) updates) => super.copyWith((message) => updates(message as NegotiateMtuInfo)) as NegotiateMtuInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static NegotiateMtuInfo create() => NegotiateMtuInfo._();
   NegotiateMtuInfo createEmptyInstance() => create();
-  static $pb.PbList<NegotiateMtuInfo> createRepeated() =>
-      $pb.PbList<NegotiateMtuInfo>();
+  static $pb.PbList<NegotiateMtuInfo> createRepeated() => $pb.PbList<NegotiateMtuInfo>();
   @$core.pragma('dart2js:noInline')
-  static NegotiateMtuInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<NegotiateMtuInfo>(create);
+  static NegotiateMtuInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NegotiateMtuInfo>(create);
   static NegotiateMtuInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1359,10 +984,7 @@ class NegotiateMtuInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get mtuSize => $_getIZ(1);
   @$pb.TagNumber(2)
-  set mtuSize($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set mtuSize($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMtuSize() => $_has(1);
   @$pb.TagNumber(2)
@@ -1371,10 +993,7 @@ class NegotiateMtuInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   GenericFailure get failure => $_getN(2);
   @$pb.TagNumber(3)
-  set failure(GenericFailure v) {
-    setField(3, v);
-  }
-
+  set failure(GenericFailure v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasFailure() => $_has(2);
   @$pb.TagNumber(3)
@@ -1384,18 +1003,10 @@ class NegotiateMtuInfo extends $pb.GeneratedMessage {
 }
 
 class BleStatusInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'BleStatusInfo',
-      createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'status',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BleStatusInfo', createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'status', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
 
   BleStatusInfo._() : super();
   factory BleStatusInfo({
@@ -1407,40 +1018,31 @@ class BleStatusInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BleStatusInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BleStatusInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory BleStatusInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BleStatusInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   BleStatusInfo clone() => BleStatusInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  BleStatusInfo copyWith(void Function(BleStatusInfo) updates) =>
-      super.copyWith((message) => updates(message as BleStatusInfo))
-          as BleStatusInfo; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BleStatusInfo copyWith(void Function(BleStatusInfo) updates) => super.copyWith((message) => updates(message as BleStatusInfo)) as BleStatusInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BleStatusInfo create() => BleStatusInfo._();
   BleStatusInfo createEmptyInstance() => create();
-  static $pb.PbList<BleStatusInfo> createRepeated() =>
-      $pb.PbList<BleStatusInfo>();
+  static $pb.PbList<BleStatusInfo> createRepeated() => $pb.PbList<BleStatusInfo>();
   @$core.pragma('dart2js:noInline')
-  static BleStatusInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<BleStatusInfo>(create);
+  static BleStatusInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BleStatusInfo>(create);
   static BleStatusInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get status => $_getIZ(0);
   @$pb.TagNumber(1)
-  set status($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set status($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasStatus() => $_has(0);
   @$pb.TagNumber(1)
@@ -1448,26 +1050,11 @@ class BleStatusInfo extends $pb.GeneratedMessage {
 }
 
 class ChangeConnectionPriorityRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChangeConnectionPriorityRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core
-                .bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..a<
-            $core.int>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'priority',
-        $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChangeConnectionPriorityRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'priority', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
 
   ChangeConnectionPriorityRequest._() : super();
   factory ChangeConnectionPriorityRequest({
@@ -1483,45 +1070,31 @@ class ChangeConnectionPriorityRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ChangeConnectionPriorityRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChangeConnectionPriorityRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChangeConnectionPriorityRequest clone() =>
-      ChangeConnectionPriorityRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChangeConnectionPriorityRequest copyWith(
-          void Function(ChangeConnectionPriorityRequest) updates) =>
-      super.copyWith(
-              (message) => updates(message as ChangeConnectionPriorityRequest))
-          as ChangeConnectionPriorityRequest; // ignore: deprecated_member_use
+  factory ChangeConnectionPriorityRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangeConnectionPriorityRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ChangeConnectionPriorityRequest clone() => ChangeConnectionPriorityRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangeConnectionPriorityRequest copyWith(void Function(ChangeConnectionPriorityRequest) updates) => super.copyWith((message) => updates(message as ChangeConnectionPriorityRequest)) as ChangeConnectionPriorityRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static ChangeConnectionPriorityRequest create() =>
-      ChangeConnectionPriorityRequest._();
+  static ChangeConnectionPriorityRequest create() => ChangeConnectionPriorityRequest._();
   ChangeConnectionPriorityRequest createEmptyInstance() => create();
-  static $pb.PbList<ChangeConnectionPriorityRequest> createRepeated() =>
-      $pb.PbList<ChangeConnectionPriorityRequest>();
+  static $pb.PbList<ChangeConnectionPriorityRequest> createRepeated() => $pb.PbList<ChangeConnectionPriorityRequest>();
   @$core.pragma('dart2js:noInline')
-  static ChangeConnectionPriorityRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ChangeConnectionPriorityRequest>(
-          create);
+  static ChangeConnectionPriorityRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangeConnectionPriorityRequest>(create);
   static ChangeConnectionPriorityRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1530,10 +1103,7 @@ class ChangeConnectionPriorityRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get priority => $_getIZ(1);
   @$pb.TagNumber(2)
-  set priority($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set priority($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasPriority() => $_has(1);
   @$pb.TagNumber(2)
@@ -1541,24 +1111,11 @@ class ChangeConnectionPriorityRequest extends $pb.GeneratedMessage {
 }
 
 class ChangeConnectionPriorityInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ChangeConnectionPriorityInfo',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..aOM<GenericFailure>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'failure',
-        subBuilder: GenericFailure.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ChangeConnectionPriorityInfo', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..aOM<GenericFailure>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'failure', subBuilder: GenericFailure.create)
+    ..hasRequiredFields = false
+  ;
 
   ChangeConnectionPriorityInfo._() : super();
   factory ChangeConnectionPriorityInfo({
@@ -1574,44 +1131,31 @@ class ChangeConnectionPriorityInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ChangeConnectionPriorityInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ChangeConnectionPriorityInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ChangeConnectionPriorityInfo clone() =>
-      ChangeConnectionPriorityInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ChangeConnectionPriorityInfo copyWith(
-          void Function(ChangeConnectionPriorityInfo) updates) =>
-      super.copyWith(
-              (message) => updates(message as ChangeConnectionPriorityInfo))
-          as ChangeConnectionPriorityInfo; // ignore: deprecated_member_use
+  factory ChangeConnectionPriorityInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ChangeConnectionPriorityInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ChangeConnectionPriorityInfo clone() => ChangeConnectionPriorityInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ChangeConnectionPriorityInfo copyWith(void Function(ChangeConnectionPriorityInfo) updates) => super.copyWith((message) => updates(message as ChangeConnectionPriorityInfo)) as ChangeConnectionPriorityInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static ChangeConnectionPriorityInfo create() =>
-      ChangeConnectionPriorityInfo._();
+  static ChangeConnectionPriorityInfo create() => ChangeConnectionPriorityInfo._();
   ChangeConnectionPriorityInfo createEmptyInstance() => create();
-  static $pb.PbList<ChangeConnectionPriorityInfo> createRepeated() =>
-      $pb.PbList<ChangeConnectionPriorityInfo>();
+  static $pb.PbList<ChangeConnectionPriorityInfo> createRepeated() => $pb.PbList<ChangeConnectionPriorityInfo>();
   @$core.pragma('dart2js:noInline')
-  static ChangeConnectionPriorityInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ChangeConnectionPriorityInfo>(create);
+  static ChangeConnectionPriorityInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ChangeConnectionPriorityInfo>(create);
   static ChangeConnectionPriorityInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1620,10 +1164,7 @@ class ChangeConnectionPriorityInfo extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   GenericFailure get failure => $_getN(1);
   @$pb.TagNumber(2)
-  set failure(GenericFailure v) {
-    setField(2, v);
-  }
-
+  set failure(GenericFailure v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasFailure() => $_has(1);
   @$pb.TagNumber(2)
@@ -1633,29 +1174,12 @@ class ChangeConnectionPriorityInfo extends $pb.GeneratedMessage {
 }
 
 class CharacteristicAddress extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'CharacteristicAddress',
-      createEmptyInstance: create)
-    ..aOS(
-        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId',
-        protoName: 'deviceId')
-    ..aOM<Uuid>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'serviceUuid',
-        protoName: 'serviceUuid',
-        subBuilder: Uuid.create)
-    ..aOM<Uuid>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristicUuid',
-        protoName: 'characteristicUuid',
-        subBuilder: Uuid.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CharacteristicAddress', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..aOM<Uuid>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuid', protoName: 'serviceUuid', subBuilder: Uuid.create)
+    ..aOM<Uuid>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristicUuid', protoName: 'characteristicUuid', subBuilder: Uuid.create)
+    ..hasRequiredFields = false
+  ;
 
   CharacteristicAddress._() : super();
   factory CharacteristicAddress({
@@ -1675,42 +1199,31 @@ class CharacteristicAddress extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CharacteristicAddress.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CharacteristicAddress.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  CharacteristicAddress clone() =>
-      CharacteristicAddress()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  CharacteristicAddress copyWith(
-          void Function(CharacteristicAddress) updates) =>
-      super.copyWith((message) => updates(message as CharacteristicAddress))
-          as CharacteristicAddress; // ignore: deprecated_member_use
+  factory CharacteristicAddress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CharacteristicAddress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CharacteristicAddress clone() => CharacteristicAddress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CharacteristicAddress copyWith(void Function(CharacteristicAddress) updates) => super.copyWith((message) => updates(message as CharacteristicAddress)) as CharacteristicAddress; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CharacteristicAddress create() => CharacteristicAddress._();
   CharacteristicAddress createEmptyInstance() => create();
-  static $pb.PbList<CharacteristicAddress> createRepeated() =>
-      $pb.PbList<CharacteristicAddress>();
+  static $pb.PbList<CharacteristicAddress> createRepeated() => $pb.PbList<CharacteristicAddress>();
   @$core.pragma('dart2js:noInline')
-  static CharacteristicAddress getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CharacteristicAddress>(create);
+  static CharacteristicAddress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CharacteristicAddress>(create);
   static CharacteristicAddress? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1719,10 +1232,7 @@ class CharacteristicAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   Uuid get serviceUuid => $_getN(1);
   @$pb.TagNumber(2)
-  set serviceUuid(Uuid v) {
-    setField(2, v);
-  }
-
+  set serviceUuid(Uuid v) { setField(2, v); }
   @$pb.TagNumber(2)
   $core.bool hasServiceUuid() => $_has(1);
   @$pb.TagNumber(2)
@@ -1733,10 +1243,7 @@ class CharacteristicAddress extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   Uuid get characteristicUuid => $_getN(2);
   @$pb.TagNumber(3)
-  set characteristicUuid(Uuid v) {
-    setField(3, v);
-  }
-
+  set characteristicUuid(Uuid v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasCharacteristicUuid() => $_has(2);
   @$pb.TagNumber(3)
@@ -1746,25 +1253,11 @@ class CharacteristicAddress extends $pb.GeneratedMessage {
 }
 
 class ServiceDataEntry extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ServiceDataEntry',
-      createEmptyInstance: create)
-    ..aOM<Uuid>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'serviceUuid',
-        protoName: 'serviceUuid',
-        subBuilder: Uuid.create)
-    ..a<$core.List<$core.int>>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ServiceDataEntry', createEmptyInstance: create)
+    ..aOM<Uuid>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuid', protoName: 'serviceUuid', subBuilder: Uuid.create)
+    ..a<$core.List<$core.int>>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
 
   ServiceDataEntry._() : super();
   factory ServiceDataEntry({
@@ -1780,40 +1273,31 @@ class ServiceDataEntry extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ServiceDataEntry.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ServiceDataEntry.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory ServiceDataEntry.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ServiceDataEntry.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ServiceDataEntry clone() => ServiceDataEntry()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ServiceDataEntry copyWith(void Function(ServiceDataEntry) updates) =>
-      super.copyWith((message) => updates(message as ServiceDataEntry))
-          as ServiceDataEntry; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ServiceDataEntry copyWith(void Function(ServiceDataEntry) updates) => super.copyWith((message) => updates(message as ServiceDataEntry)) as ServiceDataEntry; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceDataEntry create() => ServiceDataEntry._();
   ServiceDataEntry createEmptyInstance() => create();
-  static $pb.PbList<ServiceDataEntry> createRepeated() =>
-      $pb.PbList<ServiceDataEntry>();
+  static $pb.PbList<ServiceDataEntry> createRepeated() => $pb.PbList<ServiceDataEntry>();
   @$core.pragma('dart2js:noInline')
-  static ServiceDataEntry getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ServiceDataEntry>(create);
+  static ServiceDataEntry getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ServiceDataEntry>(create);
   static ServiceDataEntry? _defaultInstance;
 
   @$pb.TagNumber(1)
   Uuid get serviceUuid => $_getN(0);
   @$pb.TagNumber(1)
-  set serviceUuid(Uuid v) {
-    setField(1, v);
-  }
-
+  set serviceUuid(Uuid v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasServiceUuid() => $_has(0);
   @$pb.TagNumber(1)
@@ -1824,10 +1308,7 @@ class ServiceDataEntry extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.List<$core.int> get data => $_getN(1);
   @$pb.TagNumber(2)
-  set data($core.List<$core.int> v) {
-    $_setBytes(1, v);
-  }
-
+  set data($core.List<$core.int> v) { $_setBytes(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasData() => $_has(1);
   @$pb.TagNumber(2)
@@ -1835,19 +1316,10 @@ class ServiceDataEntry extends $pb.GeneratedMessage {
 }
 
 class ServicesWithCharacteristics extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ServicesWithCharacteristics',
-      createEmptyInstance: create)
-    ..pc<ServiceWithCharacteristics>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'items',
-        $pb.PbFieldType.PM,
-        subBuilder: ServiceWithCharacteristics.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ServicesWithCharacteristics', createEmptyInstance: create)
+    ..pc<ServiceWithCharacteristics>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: ServiceWithCharacteristics.create)
+    ..hasRequiredFields = false
+  ;
 
   ServicesWithCharacteristics._() : super();
   factory ServicesWithCharacteristics({
@@ -1859,35 +1331,25 @@ class ServicesWithCharacteristics extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ServicesWithCharacteristics.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ServicesWithCharacteristics.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ServicesWithCharacteristics clone() =>
-      ServicesWithCharacteristics()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ServicesWithCharacteristics copyWith(
-          void Function(ServicesWithCharacteristics) updates) =>
-      super.copyWith(
-              (message) => updates(message as ServicesWithCharacteristics))
-          as ServicesWithCharacteristics; // ignore: deprecated_member_use
+  factory ServicesWithCharacteristics.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ServicesWithCharacteristics.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ServicesWithCharacteristics clone() => ServicesWithCharacteristics()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ServicesWithCharacteristics copyWith(void Function(ServicesWithCharacteristics) updates) => super.copyWith((message) => updates(message as ServicesWithCharacteristics)) as ServicesWithCharacteristics; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
-  static ServicesWithCharacteristics create() =>
-      ServicesWithCharacteristics._();
+  static ServicesWithCharacteristics create() => ServicesWithCharacteristics._();
   ServicesWithCharacteristics createEmptyInstance() => create();
-  static $pb.PbList<ServicesWithCharacteristics> createRepeated() =>
-      $pb.PbList<ServicesWithCharacteristics>();
+  static $pb.PbList<ServicesWithCharacteristics> createRepeated() => $pb.PbList<ServicesWithCharacteristics>();
   @$core.pragma('dart2js:noInline')
-  static ServicesWithCharacteristics getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ServicesWithCharacteristics>(create);
+  static ServicesWithCharacteristics getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ServicesWithCharacteristics>(create);
   static ServicesWithCharacteristics? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1895,26 +1357,11 @@ class ServicesWithCharacteristics extends $pb.GeneratedMessage {
 }
 
 class ServiceWithCharacteristics extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'ServiceWithCharacteristics',
-      createEmptyInstance: create)
-    ..aOM<Uuid>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'serviceId',
-        protoName: 'serviceId',
-        subBuilder: Uuid.create)
-    ..pc<Uuid>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristics',
-        $pb.PbFieldType.PM,
-        subBuilder: Uuid.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ServiceWithCharacteristics', createEmptyInstance: create)
+    ..aOM<Uuid>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceId', protoName: 'serviceId', subBuilder: Uuid.create)
+    ..pc<Uuid>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristics', $pb.PbFieldType.PM, subBuilder: Uuid.create)
+    ..hasRequiredFields = false
+  ;
 
   ServiceWithCharacteristics._() : super();
   factory ServiceWithCharacteristics({
@@ -1930,43 +1377,31 @@ class ServiceWithCharacteristics extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ServiceWithCharacteristics.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ServiceWithCharacteristics.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  ServiceWithCharacteristics clone() =>
-      ServiceWithCharacteristics()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ServiceWithCharacteristics copyWith(
-          void Function(ServiceWithCharacteristics) updates) =>
-      super.copyWith(
-              (message) => updates(message as ServiceWithCharacteristics))
-          as ServiceWithCharacteristics; // ignore: deprecated_member_use
+  factory ServiceWithCharacteristics.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ServiceWithCharacteristics.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  ServiceWithCharacteristics clone() => ServiceWithCharacteristics()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ServiceWithCharacteristics copyWith(void Function(ServiceWithCharacteristics) updates) => super.copyWith((message) => updates(message as ServiceWithCharacteristics)) as ServiceWithCharacteristics; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ServiceWithCharacteristics create() => ServiceWithCharacteristics._();
   ServiceWithCharacteristics createEmptyInstance() => create();
-  static $pb.PbList<ServiceWithCharacteristics> createRepeated() =>
-      $pb.PbList<ServiceWithCharacteristics>();
+  static $pb.PbList<ServiceWithCharacteristics> createRepeated() => $pb.PbList<ServiceWithCharacteristics>();
   @$core.pragma('dart2js:noInline')
-  static ServiceWithCharacteristics getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ServiceWithCharacteristics>(create);
+  static ServiceWithCharacteristics getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ServiceWithCharacteristics>(create);
   static ServiceWithCharacteristics? _defaultInstance;
 
   @$pb.TagNumber(1)
   Uuid get serviceId => $_getN(0);
   @$pb.TagNumber(1)
-  set serviceId(Uuid v) {
-    setField(1, v);
-  }
-
+  set serviceId(Uuid v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasServiceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -1979,18 +1414,10 @@ class ServiceWithCharacteristics extends $pb.GeneratedMessage {
 }
 
 class DiscoverServicesRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DiscoverServicesRequest',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DiscoverServicesRequest', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..hasRequiredFields = false
+  ;
 
   DiscoverServicesRequest._() : super();
   factory DiscoverServicesRequest({
@@ -2002,42 +1429,31 @@ class DiscoverServicesRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DiscoverServicesRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DiscoverServicesRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DiscoverServicesRequest clone() =>
-      DiscoverServicesRequest()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DiscoverServicesRequest copyWith(
-          void Function(DiscoverServicesRequest) updates) =>
-      super.copyWith((message) => updates(message as DiscoverServicesRequest))
-          as DiscoverServicesRequest; // ignore: deprecated_member_use
+  factory DiscoverServicesRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DiscoverServicesRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DiscoverServicesRequest clone() => DiscoverServicesRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DiscoverServicesRequest copyWith(void Function(DiscoverServicesRequest) updates) => super.copyWith((message) => updates(message as DiscoverServicesRequest)) as DiscoverServicesRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DiscoverServicesRequest create() => DiscoverServicesRequest._();
   DiscoverServicesRequest createEmptyInstance() => create();
-  static $pb.PbList<DiscoverServicesRequest> createRepeated() =>
-      $pb.PbList<DiscoverServicesRequest>();
+  static $pb.PbList<DiscoverServicesRequest> createRepeated() => $pb.PbList<DiscoverServicesRequest>();
   @$core.pragma('dart2js:noInline')
-  static DiscoverServicesRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DiscoverServicesRequest>(create);
+  static DiscoverServicesRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DiscoverServicesRequest>(create);
   static DiscoverServicesRequest? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2045,26 +1461,11 @@ class DiscoverServicesRequest extends $pb.GeneratedMessage {
 }
 
 class DiscoverServicesInfo extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DiscoverServicesInfo',
-      createEmptyInstance: create)
-    ..aOS(
-        1,
-        const $core
-                .bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'deviceId',
-        protoName: 'deviceId')
-    ..pc<DiscoveredService>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'services',
-        $pb.PbFieldType.PM,
-        subBuilder: DiscoveredService.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DiscoverServicesInfo', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'deviceId', protoName: 'deviceId')
+    ..pc<DiscoveredService>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'services', $pb.PbFieldType.PM, subBuilder: DiscoveredService.create)
+    ..hasRequiredFields = false
+  ;
 
   DiscoverServicesInfo._() : super();
   factory DiscoverServicesInfo({
@@ -2080,41 +1481,31 @@ class DiscoverServicesInfo extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DiscoverServicesInfo.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DiscoverServicesInfo.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
-  DiscoverServicesInfo clone() =>
-      DiscoverServicesInfo()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DiscoverServicesInfo copyWith(void Function(DiscoverServicesInfo) updates) =>
-      super.copyWith((message) => updates(message as DiscoverServicesInfo))
-          as DiscoverServicesInfo; // ignore: deprecated_member_use
+  factory DiscoverServicesInfo.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DiscoverServicesInfo.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DiscoverServicesInfo clone() => DiscoverServicesInfo()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DiscoverServicesInfo copyWith(void Function(DiscoverServicesInfo) updates) => super.copyWith((message) => updates(message as DiscoverServicesInfo)) as DiscoverServicesInfo; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DiscoverServicesInfo create() => DiscoverServicesInfo._();
   DiscoverServicesInfo createEmptyInstance() => create();
-  static $pb.PbList<DiscoverServicesInfo> createRepeated() =>
-      $pb.PbList<DiscoverServicesInfo>();
+  static $pb.PbList<DiscoverServicesInfo> createRepeated() => $pb.PbList<DiscoverServicesInfo>();
   @$core.pragma('dart2js:noInline')
-  static DiscoverServicesInfo getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DiscoverServicesInfo>(create);
+  static DiscoverServicesInfo getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DiscoverServicesInfo>(create);
   static DiscoverServicesInfo? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get deviceId => $_getSZ(0);
   @$pb.TagNumber(1)
-  set deviceId($core.String v) {
-    $_setString(0, v);
-  }
-
+  set deviceId($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasDeviceId() => $_has(0);
   @$pb.TagNumber(1)
@@ -2125,28 +1516,12 @@ class DiscoverServicesInfo extends $pb.GeneratedMessage {
 }
 
 class DiscoveredService extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'DiscoveredService',
-      createEmptyInstance: create)
-    ..aOM<Uuid>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuid',
-        protoName: 'serviceUuid', subBuilder: Uuid.create)
-    ..pc<Uuid>(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'characteristicUuids',
-        $pb.PbFieldType.PM,
-        protoName: 'characteristicUuids',
-        subBuilder: Uuid.create)
-    ..pc<DiscoveredService>(
-        3,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'includedServices',
-        $pb.PbFieldType.PM,
-        protoName: 'includedServices',
-        subBuilder: DiscoveredService.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DiscoveredService', createEmptyInstance: create)
+    ..aOM<Uuid>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'serviceUuid', protoName: 'serviceUuid', subBuilder: Uuid.create)
+    ..pc<Uuid>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'characteristicUuids', $pb.PbFieldType.PM, protoName: 'characteristicUuids', subBuilder: Uuid.create)
+    ..pc<DiscoveredService>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'includedServices', $pb.PbFieldType.PM, protoName: 'includedServices', subBuilder: DiscoveredService.create)
+    ..hasRequiredFields = false
+  ;
 
   DiscoveredService._() : super();
   factory DiscoveredService({
@@ -2166,40 +1541,31 @@ class DiscoveredService extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DiscoveredService.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DiscoveredService.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory DiscoveredService.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DiscoveredService.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DiscoveredService clone() => DiscoveredService()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  DiscoveredService copyWith(void Function(DiscoveredService) updates) =>
-      super.copyWith((message) => updates(message as DiscoveredService))
-          as DiscoveredService; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DiscoveredService copyWith(void Function(DiscoveredService) updates) => super.copyWith((message) => updates(message as DiscoveredService)) as DiscoveredService; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DiscoveredService create() => DiscoveredService._();
   DiscoveredService createEmptyInstance() => create();
-  static $pb.PbList<DiscoveredService> createRepeated() =>
-      $pb.PbList<DiscoveredService>();
+  static $pb.PbList<DiscoveredService> createRepeated() => $pb.PbList<DiscoveredService>();
   @$core.pragma('dart2js:noInline')
-  static DiscoveredService getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DiscoveredService>(create);
+  static DiscoveredService getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DiscoveredService>(create);
   static DiscoveredService? _defaultInstance;
 
   @$pb.TagNumber(1)
   Uuid get serviceUuid => $_getN(0);
   @$pb.TagNumber(1)
-  set serviceUuid(Uuid v) {
-    setField(1, v);
-  }
-
+  set serviceUuid(Uuid v) { setField(1, v); }
   @$pb.TagNumber(1)
   $core.bool hasServiceUuid() => $_has(0);
   @$pb.TagNumber(1)
@@ -2215,18 +1581,10 @@ class DiscoveredService extends $pb.GeneratedMessage {
 }
 
 class Uuid extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'Uuid',
-      createEmptyInstance: create)
-    ..a<$core.List<$core.int>>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'data',
-        $pb.PbFieldType.OY)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Uuid', createEmptyInstance: create)
+    ..a<$core.List<$core.int>>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'data', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false
+  ;
 
   Uuid._() : super();
   factory Uuid({
@@ -2238,39 +1596,31 @@ class Uuid extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Uuid.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Uuid.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Uuid.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Uuid.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Uuid clone() => Uuid()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Uuid copyWith(void Function(Uuid) updates) =>
-      super.copyWith((message) => updates(message as Uuid))
-          as Uuid; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Uuid copyWith(void Function(Uuid) updates) => super.copyWith((message) => updates(message as Uuid)) as Uuid; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Uuid create() => Uuid._();
   Uuid createEmptyInstance() => create();
   static $pb.PbList<Uuid> createRepeated() => $pb.PbList<Uuid>();
   @$core.pragma('dart2js:noInline')
-  static Uuid getDefault() =>
-      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Uuid>(create);
+  static Uuid getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Uuid>(create);
   static Uuid? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.List<$core.int> get data => $_getN(0);
   @$pb.TagNumber(1)
-  set data($core.List<$core.int> v) {
-    $_setBytes(0, v);
-  }
-
+  set data($core.List<$core.int> v) { $_setBytes(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasData() => $_has(0);
   @$pb.TagNumber(1)
@@ -2278,23 +1628,11 @@ class Uuid extends $pb.GeneratedMessage {
 }
 
 class GenericFailure extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names')
-          ? ''
-          : 'GenericFailure',
-      createEmptyInstance: create)
-    ..a<$core.int>(
-        1,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'code',
-        $pb.PbFieldType.O3)
-    ..aOS(
-        2,
-        const $core.bool.fromEnvironment('protobuf.omit_field_names')
-            ? ''
-            : 'message')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GenericFailure', createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'code', $pb.PbFieldType.O3)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
 
   GenericFailure._() : super();
   factory GenericFailure({
@@ -2310,40 +1648,31 @@ class GenericFailure extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GenericFailure.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory GenericFailure.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory GenericFailure.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GenericFailure.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   GenericFailure clone() => GenericFailure()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  GenericFailure copyWith(void Function(GenericFailure) updates) =>
-      super.copyWith((message) => updates(message as GenericFailure))
-          as GenericFailure; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GenericFailure copyWith(void Function(GenericFailure) updates) => super.copyWith((message) => updates(message as GenericFailure)) as GenericFailure; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GenericFailure create() => GenericFailure._();
   GenericFailure createEmptyInstance() => create();
-  static $pb.PbList<GenericFailure> createRepeated() =>
-      $pb.PbList<GenericFailure>();
+  static $pb.PbList<GenericFailure> createRepeated() => $pb.PbList<GenericFailure>();
   @$core.pragma('dart2js:noInline')
-  static GenericFailure getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<GenericFailure>(create);
+  static GenericFailure getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GenericFailure>(create);
   static GenericFailure? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get code => $_getIZ(0);
   @$pb.TagNumber(1)
-  set code($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set code($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCode() => $_has(0);
   @$pb.TagNumber(1)
@@ -2352,12 +1681,10 @@ class GenericFailure extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get message => $_getSZ(1);
   @$pb.TagNumber(2)
-  set message($core.String v) {
-    $_setString(1, v);
-  }
-
+  set message($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasMessage() => $_has(1);
   @$pb.TagNumber(2)
   void clearMessage() => clearField(2);
 }
+

--- a/lib/src/model/discovered_device.dart
+++ b/lib/src/model/discovered_device.dart
@@ -36,6 +36,9 @@ class DiscoveredDevice extends $DiscoveredDevice {
   /// Manufacturer specific data. The first 2 bytes are the Company Identifier Codes.
   final Uint8List manufacturerData;
 
+  /// Raw scan record
+  final Uint8List rawScanRecordData;
+
   final int rssi;
 
   const DiscoveredDevice({
@@ -45,6 +48,7 @@ class DiscoveredDevice extends $DiscoveredDevice {
     required this.serviceUuids,
     required this.manufacturerData,
     required this.rssi,
+    required this.rawScanRecordData,
   });
 }
 

--- a/lib/src/model/discovered_device.g.dart
+++ b/lib/src/model/discovered_device.g.dart
@@ -17,6 +17,7 @@ abstract class $DiscoveredDevice {
   Map<Uuid, Uint8List> get serviceData;
   List<Uuid> get serviceUuids;
   Uint8List get manufacturerData;
+  Uint8List get rawScanRecordData;
   int get rssi;
   DiscoveredDevice copyWith(
           {String? id,
@@ -24,6 +25,7 @@ abstract class $DiscoveredDevice {
           Map<Uuid, Uint8List>? serviceData,
           List<Uuid>? serviceUuids,
           Uint8List? manufacturerData,
+          Uint8List? rawScanRecordData,
           int? rssi}) =>
       DiscoveredDevice(
           id: id ?? this.id,
@@ -31,10 +33,11 @@ abstract class $DiscoveredDevice {
           serviceData: serviceData ?? this.serviceData,
           serviceUuids: serviceUuids ?? this.serviceUuids,
           manufacturerData: manufacturerData ?? this.manufacturerData,
+          rawScanRecordData: rawScanRecordData ?? this.rawScanRecordData,
           rssi: rssi ?? this.rssi);
   @override
   String toString() =>
-      "DiscoveredDevice(id: $id, name: $name, serviceData: $serviceData, serviceUuids: $serviceUuids, manufacturerData: $manufacturerData, rssi: $rssi)";
+      "DiscoveredDevice(id: $id, name: $name, serviceData: $serviceData, serviceUuids: $serviceUuids, manufacturerData: $manufacturerData, rawScanRecordData: $rawScanRecordData, rssi: $rssi)";
   @override
   bool operator ==(Object other) =>
       other is DiscoveredDevice &&
@@ -44,6 +47,7 @@ abstract class $DiscoveredDevice {
       const DeepCollectionEquality().equals(serviceData, other.serviceData) &&
       const DeepCollectionEquality().equals(serviceUuids, other.serviceUuids) &&
       manufacturerData == other.manufacturerData &&
+      rawScanRecordData == other.rawScanRecordData &&
       rssi == other.rssi;
   @override
   int get hashCode {
@@ -53,6 +57,7 @@ abstract class $DiscoveredDevice {
     result = 37 * result + const DeepCollectionEquality().hash(serviceData);
     result = 37 * result + const DeepCollectionEquality().hash(serviceUuids);
     result = 37 * result + manufacturerData.hashCode;
+    result = 37 * result + rawScanRecordData.hashCode;
     result = 37 * result + rssi.hashCode;
     return result;
   }
@@ -73,6 +78,10 @@ class DiscoveredDevice$ {
       (s_) => s_.manufacturerData,
       (s_, manufacturerData) =>
           s_.copyWith(manufacturerData: manufacturerData));
+  static final rawScanRecordData = Lens<DiscoveredDevice, Uint8List>(
+      (s_) => s_.rawScanRecordData,
+      (s_, rawScanRecordData) =>
+          s_.copyWith(rawScanRecordData: rawScanRecordData));
   static final rssi = Lens<DiscoveredDevice, int>(
       (s_) => s_.rssi, (s_, rssi) => s_.copyWith(rssi: rssi));
 }

--- a/protos/bledata.proto
+++ b/protos/bledata.proto
@@ -15,6 +15,7 @@ message DeviceScanInfo {
     repeated ServiceDataEntry serviceData = 4;
     repeated Uuid serviceUuids = 7;
     bytes manufacturerData = 6;
+    bytes rawScanRecordData = 8;
     int32 rssi = 5;
 }
 

--- a/test/device_connector_test.dart
+++ b/test/device_connector_test.dart
@@ -102,6 +102,7 @@ void main() {
         rssi: -39,
         serviceData: const {},
         serviceUuids: const [],
+        rawScanRecordData: Uint8List.fromList([0]),
       );
 
       setUp(() {

--- a/test/device_scanner_test.dart
+++ b/test/device_scanner_test.dart
@@ -33,6 +33,7 @@ void main() {
         serviceUuids: const [],
         manufacturerData: Uint8List.fromList([1]),
         rssi: -40,
+        rawScanRecordData: Uint8List.fromList([1]),
       );
       _device2 = DiscoveredDevice(
         id: '456',
@@ -41,6 +42,7 @@ void main() {
         serviceUuids: const [],
         manufacturerData: Uint8List.fromList([0]),
         rssi: -80,
+        rawScanRecordData: Uint8List.fromList([1]),
       );
 
       _delayAfterScanCompletion = Completer();

--- a/test/plugin_controller_test.dart
+++ b/test/plugin_controller_test.dart
@@ -469,6 +469,7 @@ void main() {
         serviceData: const {},
         serviceUuids: const [],
         manufacturerData: Uint8List.fromList([1]),
+        rawScanRecordData: Uint8List.fromList([1]),
       );
       late ScanResult scanResult;
 

--- a/test/reactive_ble_test.dart
+++ b/test/reactive_ble_test.dart
@@ -242,6 +242,7 @@ void main() {
         rssi: -39,
         serviceData: const {},
         serviceUuids: const [],
+        rawScanRecordData: Uint8List.fromList([1]),
       );
       Stream<DiscoveredDevice>? deviceStream;
 


### PR DESCRIPTION
Is there any way to create an accessor for raw scan responses? The manufacturer advertisement data does not contain all of the data broadcasted by the peripheral if the peripheral doesn't correctly adhere to the generally accepted Bluetooth specifications. This is only an issue on Android and is described further in this relevant [issue](https://github.com/pauldemarco/flutter_blue/issues/102#issuecomment-428087684) in the flutter_blue library.  
  
My workaround for this on the native application which my team previously supported (using Java+Kotlin) was to access the raw signed scan record bytes. This isn't something which is available just yet on this library. 

Is there any way we could think about including it? Thank you guys so much for creating this great package. I've attached a first stab attempt at implementing this raw scan record.