### PR TITLE
Bump dependency of dependency_validator

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.10.11
-  dependency_validator: ^2.0.1
+  dependency_validator: ^3.1.0
   flutter_test:
     sdk: flutter
   functional_data_generator: ^1.0.0-nullsafety.1 


### PR DESCRIPTION
Done because version 2 depends on args ^1.5.0, which conflicts with dbus.dart which required ^2.0.0 