### PR TITLE
ios: Queue up discovery messages

### DIFF
--- a/packages/reactive_ble_mobile/ios/Classes/Plugin/SwiftReactiveBlePlugin.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Plugin/SwiftReactiveBlePlugin.swift
@@ -52,7 +52,7 @@ public class SwiftReactiveBlePlugin: NSObject, FlutterPlugin {
             context: context,
             onListen: { context, sink in
                 context.connectedDeviceSink = sink
-                context.flushQueue(sink: sink, queue: context.discoveryQueue)
+                context.flushQueue(sink: sink, queue: &context.discoveryQueue)
                 return nil
             },
             onCancel: { context in
@@ -69,7 +69,7 @@ public class SwiftReactiveBlePlugin: NSObject, FlutterPlugin {
             context: context,
             onListen: { context, sink in
                 context.characteristicValueUpdateSink = sink
-                context.flushQueue(sink: sink, queue: context.valueQueue)
+                context.flushQueue(sink: sink, queue: &context.valueQueue)
                 return nil
             },
             onCancel: { context in


### PR DESCRIPTION
Similar to characteristic values, queue up discovery messages until sink is ready.

This fixes both lost events and assertion errors if data comes in before listener is ready

Closes #385