### PR TITLE
prepare release 5.0.0

### DIFF
--- a/packages/flutter_reactive_ble/CHANGELOG.md
+++ b/packages/flutter_reactive_ble/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Main releases
+## 5.0.0
+
+* `DiscoveredService` has now a new required property called `DiscoveredCharacteristic` which provides properties of the BLE characteristic.
+* Android 12 support.
+* Queue up messages on iOS until event channel is ready. Fixes #137, #251, #307, #385, #387.
 
 ## 4.1.0
 

--- a/packages/flutter_reactive_ble/pubspec.lock
+++ b/packages/flutter_reactive_ble/pubspec.lock
@@ -374,14 +374,14 @@ packages:
       name: reactive_ble_mobile
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "5.0.0"
   reactive_ble_platform_interface:
     dependency: "direct main"
     description:
       name: reactive_ble_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reactive_ble
 description: Reactive Bluetooth Low Energy (BLE) plugin that can communicate with multiple devices
-version: 4.1.0
+version: 5.0.0
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:
@@ -21,8 +21,8 @@ dependencies:
     sdk: flutter
   functional_data: ^1.0.0
   meta: ^1.3.0
-  reactive_ble_mobile: ^4.0.1
-  reactive_ble_platform_interface: ^4.0.1
+  reactive_ble_mobile: ^5.0.0
+  reactive_ble_platform_interface: ^5.0.0
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_lints: ^1.0.4

--- a/packages/reactive_ble_mobile/CHANGELOG.md
+++ b/packages/reactive_ble_mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 5.0.0
+
+* `DiscoveredService` has now a new required property called `DiscoveredCharacteristic` which provides properties of the BLE characteristic.
+* Android 12 support.
+* Queue up messages on iOS until event channel is ready. Fixes #137, #251, #307, #385, #387.
+
 ## 4.1.0
 
 * Add support Android 12

--- a/packages/reactive_ble_mobile/pubspec.lock
+++ b/packages/reactive_ble_mobile/pubspec.lock
@@ -353,7 +353,7 @@ packages:
       name: reactive_ble_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   shelf:
     dependency: transitive
     description:

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_ble_mobile
 description: Official Android and iOS implementation for the flutter_reactive_ble plugin.
-version: 4.1.0
+version: 5.0.0
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   protobuf: ^2.0.0
-  reactive_ble_platform_interface: ^4.0.1
+  reactive_ble_platform_interface: ^5.0.0
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_test:

--- a/packages/reactive_ble_platform_interface/CHANGELOG.md
+++ b/packages/reactive_ble_platform_interface/CHANGELOG.md
@@ -1,4 +1,11 @@
-# Main releases
+## 5.0.0
+
+** Breaking change **
+* DiscoveredService has now a new required property called `DiscoveredCharacteristic` which provides properties of the BLE characteristic.
+
+Other changes
+* Android 12 support.
+* Queue up messages on iOS until event channel is ready. Fixes #137, #251, #307, #385, #387.
 
 ## 4.0.1
 

--- a/packages/reactive_ble_platform_interface/pubspec.yaml
+++ b/packages/reactive_ble_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: reactive_ble_platform_interface
 description: Platform interface for the flutter_reactive_ble_project 
-version: 4.0.1
+version: 5.0.0
 homepage: https://github.com/PhilipsHue/flutter_reactive_ble
 
 environment:


### PR DESCRIPTION
Do not merge because we need to update the pubspec.lock files.  I need to publish the platform interface and then the mobile package to pub.dev before we can merge it. Still before uploading it would be good to check the changelog.

- [ ]  Upload packages after approval