### PR TITLE
Restore support for Xcode 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,15 +178,6 @@ This project uses melos to manage all the packages inside this repo.
 Install melos: `dart pub global activate melos`
 Setup melos to point to the dependencies in your local folder: `melos bootstrap`
 
-### Xcode 13 breaking changes
-
-Version `4.0.1` added breaking changes for Xcode 13 that are not backwards compatible with Xcode 12. Due to this all users that are not ready to upgrade to Xcode 13 are at adviced to add the following dependency override to the pubspec.yaml of your app untill you are ready to upgrade to the latest Xcode.
-
-```yaml
-dependency_overrides:
-  reactive_ble_mobile: '4.0.0'
-```
-
 ### FAQ
 
 #### How to handle the BLE undeliverable exception

--- a/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
@@ -1,3 +1,8 @@
+#if compiler(<5.5)
+import class CoreBluetooth.CBCharacteristic
+import class CoreBluetooth.CBService
+import class CoreBluetooth.CBPeripheral
+
 // Extensions below are supposed to backport API breaking changes
 // in CoreBluetooth framework which Apple introduced with Xcode 13:
 //
@@ -12,11 +17,6 @@
 //
 // - Note: This code compiles only when using Xcode 12 and below.
 // - SeeAlso: https://forums.swift.org/t/is-unowned-unsafe-t-weak-t-a-breaking-change/49917
-
-#if compiler(<5.5)
-import class CoreBluetooth.CBCharacteristic
-import class CoreBluetooth.CBService
-import class CoreBluetooth.CBPeripheral
 
 extension CBCharacteristic {
     @nonobjc

--- a/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
@@ -1,0 +1,19 @@
+import class CoreBluetooth.CBCharacteristic
+import class CoreBluetooth.CBService
+import class CoreBluetooth.CBPeripheral
+
+#if compiler(<5.5)
+extension CBCharacteristic {
+    @nonobjc
+    var service: CBService? {
+        return value(forKey: #function) as? CBService
+    }
+}
+
+extension CBService {
+    @nonobjc
+    var peripheral: CBPeripheral? {
+        return value(forKey: #function) as? CBPeripheral
+    }
+}
+#endif

--- a/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
@@ -2,17 +2,30 @@ import class CoreBluetooth.CBCharacteristic
 import class CoreBluetooth.CBService
 import class CoreBluetooth.CBPeripheral
 
+/// Extensions below are supposed to backport API breaking changes in CoreBluetooth
+/// framework which Apple introduced with Xcode 13:
+///
+/// ```
+/// + weak var peripheral: CBPeripheral? { get }
+/// - unowned(unsafe) var peripheral: CBPeripheral { get }
+/// ```
+///
+/// Thus this code shadows original property declarations in CoreBluetooth and changes their semantics
+/// from `unsafe non-optional` to `weak optional` to mimic Xcode 13 behaviour.
+///
+/// - Note: This code compiles only when using Xcode 12 and below.
+/// - SeeAlso: https://forums.swift.org/t/is-unowned-unsafe-t-weak-t-a-breaking-change/49917
 #if compiler(<5.5)
 extension CBCharacteristic {
     @nonobjc
-    var service: CBService? {
+    weak var service: CBService? {
         return value(forKey: #function) as? CBService
     }
 }
 
 extension CBService {
     @nonobjc
-    var peripheral: CBPeripheral? {
+    weak var peripheral: CBPeripheral? {
         return value(forKey: #function) as? CBPeripheral
     }
 }

--- a/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Prelude/CoreBluetooth+Extensions.swift
@@ -1,21 +1,23 @@
+// Extensions below are supposed to backport API breaking changes
+// in CoreBluetooth framework which Apple introduced with Xcode 13:
+//
+// ```
+// + weak var peripheral: CBPeripheral? { get }
+// - unowned(unsafe) var peripheral: CBPeripheral { get }
+// ```
+//
+// Thus this code shadows original property declarations in CoreBluetooth
+// and changes their semantics from `unsafe non-optional` to `weak optional`
+// to mimic Xcode 13 behaviour.
+//
+// - Note: This code compiles only when using Xcode 12 and below.
+// - SeeAlso: https://forums.swift.org/t/is-unowned-unsafe-t-weak-t-a-breaking-change/49917
+
+#if compiler(<5.5)
 import class CoreBluetooth.CBCharacteristic
 import class CoreBluetooth.CBService
 import class CoreBluetooth.CBPeripheral
 
-/// Extensions below are supposed to backport API breaking changes in CoreBluetooth
-/// framework which Apple introduced with Xcode 13:
-///
-/// ```
-/// + weak var peripheral: CBPeripheral? { get }
-/// - unowned(unsafe) var peripheral: CBPeripheral { get }
-/// ```
-///
-/// Thus this code shadows original property declarations in CoreBluetooth and changes their semantics
-/// from `unsafe non-optional` to `weak optional` to mimic Xcode 13 behaviour.
-///
-/// - Note: This code compiles only when using Xcode 12 and below.
-/// - SeeAlso: https://forums.swift.org/t/is-unowned-unsafe-t-weak-t-a-breaking-change/49917
-#if compiler(<5.5)
 extension CBCharacteristic {
     @nonobjc
     weak var service: CBService? {


### PR DESCRIPTION
Hi! This PR makes `flutter_reactive_ble` buildable and workable both in Xcode 12 and Xcode 13, which I would appreciate since our team not planning to migrate CI/CD to Xcode 13 for at least a couple of months. Thanks.