### PR TITLE
Fix Android Permissions

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,27 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.signify.hue.reactivebleexample">
 
-    <!-- required for API 18 - 30 -->
-    <uses-permission
-            android:name="android.permission.BLUETOOTH"
-            android:maxSdkVersion="30" />
-    <uses-permission
-            android:name="android.permission.BLUETOOTH_ADMIN"
-            android:maxSdkVersion="30" />
-
-    <!-- required for API 23 - 30 -->
-    <uses-permission-sdk-23
-            android:name="android.permission.ACCESS_COARSE_LOCATION"
-            android:maxSdkVersion="30" />
-    <uses-permission-sdk-23
-            android:name="android.permission.ACCESS_FINE_LOCATION"
-            android:maxSdkVersion="30" />
-
-    <!-- API 31+ -->
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-    <uses-permission
-            android:name="android.permission.BLUETOOTH_SCAN"
-            android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
         android:label="flutter_reactive_ble_example"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,22 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.signify.hue.reactivebleexample">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <!-- required for API 18 - 30 -->
+    <uses-permission
+        android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission
+        android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+
+    <!-- required for API 23 - 30 -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <!-- API 31+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
 
     <application
         android:label="flutter_reactive_ble_example"

--- a/packages/reactive_ble_mobile/android/src/main/AndroidManifest.xml
+++ b/packages/reactive_ble_mobile/android/src/main/AndroidManifest.xml
@@ -10,12 +10,8 @@
         android:maxSdkVersion="30" />
 
     <!-- required for API 23 - 30 -->
-    <uses-permission-sdk-23
-        android:name="android.permission.ACCESS_COARSE_LOCATION"
-        android:maxSdkVersion="30" />
-    <uses-permission-sdk-23
-        android:name="android.permission.ACCESS_FINE_LOCATION"
-        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- API 31+ -->
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />


### PR DESCRIPTION
I've observed that Android 12 devices that use `ACCESS_COARSE_LOCATION` and `ACCESS_FINE_LOCATION` for purposes other than Bluetooth scanning will encounter issues when `maxSdkVersion` is enforced. 

`uses-permission-sdk-23` also makes scanning impossible for devices with SDK 21 and 22 (Android 5 and 5.1.1)

As pointed out in #477, the `INTERNET` permission is needed in the example app, but I also removed all the Bluetooth related permissions as they will get inherited from the plugin