### PR TITLE
Deinitialize in onDetachedFromEngine on Android

### DIFF
--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
@@ -71,6 +71,11 @@ class PluginController {
         bleStatusChannel.setStreamHandler(bleStatusHandler)
     }
 
+    internal fun deinitialize() {
+        scandevicesHandler.stopDeviceScan()
+        deviceConnectionHandler.disconnectAll()
+    }
+
     internal fun execute(call: MethodCall, result: Result) {
         pluginMethods[call.method]?.invoke(call, result) ?: result.notImplemented()
     }
@@ -81,8 +86,7 @@ class PluginController {
     }
 
     private fun deinitializeClient(call: MethodCall, result: Result) {
-        scandevicesHandler.stopDeviceScan()
-        deviceConnectionHandler.disconnectAll()
+        deinitialize()
         result.success(null)
     }
 

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
@@ -13,7 +13,7 @@ class ReactiveBlePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        // deinitalize logic
+        deinitalizePlugin()
     }
 
     companion object {
@@ -24,6 +24,11 @@ class ReactiveBlePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
             channel.setMethodCallHandler(ReactiveBlePlugin())
             pluginController = PluginController()
             pluginController.initialize(messenger, context)
+        }
+
+        @JvmStatic
+        private fun deinitalizePlugin() {
+            pluginController.deinitialize()
         }
     }
 

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
@@ -9,25 +9,30 @@ import io.flutter.plugin.common.MethodChannel.Result
 
 class ReactiveBlePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        initalizePlugin(binding.binaryMessenger, binding.applicationContext)
+        initializePlugin(binding.binaryMessenger, binding.applicationContext, this)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        deinitalizePlugin()
+        deinitializePlugin()
     }
 
     companion object {
         lateinit var pluginController: PluginController
+
         @JvmStatic
-        private fun initalizePlugin(messenger: BinaryMessenger, context: Context) {
+        private fun initializePlugin(
+            messenger: BinaryMessenger,
+            context: Context,
+            plugin: ReactiveBlePlugin
+        ) {
             val channel = MethodChannel(messenger, "flutter_reactive_ble_method")
-            channel.setMethodCallHandler(ReactiveBlePlugin())
+            channel.setMethodCallHandler(plugin)
             pluginController = PluginController()
             pluginController.initialize(messenger, context)
         }
 
         @JvmStatic
-        private fun deinitalizePlugin() {
+        private fun deinitializePlugin() {
             pluginController.deinitialize()
         }
     }

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -45,7 +45,7 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
 
         lateinit var rxBleClient: RxBleClient
             internal set
-        internal lateinit var activeConnections: MutableMap<String, DeviceConnector>
+        internal var activeConnections = mutableMapOf<String, DeviceConnector>()
     }
 
     override val connectionUpdateSubject: BehaviorSubject<ConnectionUpdate>


### PR DESCRIPTION
Without this, devices stay connected to detached native code and behave unexpectedly when reattached to flutter