### PR TITLE
Update README.md to enable ble scan for location on Android 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The reactive BLE lib supports the following:
 ### Android
 
 You need to add the following permissions to your AndroidManifest.xml file:
+
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
@@ -47,7 +48,13 @@ You need to add the following permissions to your AndroidManifest.xml file:
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
 ```
 
-If you use `BLUETOOTH_SCAN` to determine location, remove `android:usesPermissionFlags="neverForLocation"`
+If you use `BLUETOOTH_SCAN` to determine location, modify your AndroidManfiest.xml file to include the following entry:
+
+```xml
+ <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
+                     tools:remove="android:usesPermissionFlags"
+                     tools:targetApi="s" />
+```
 
 If you use location services in your app, remove `android:maxSdkVersion="30"` from the location permission tags
 

--- a/packages/flutter_reactive_ble/README.md
+++ b/packages/flutter_reactive_ble/README.md
@@ -22,6 +22,7 @@ The reactive BLE lib supports the following:
 ### Android
 
 You need to add the following permissions to your AndroidManifest.xml file:
+
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
@@ -29,7 +30,13 @@ You need to add the following permissions to your AndroidManifest.xml file:
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
 ```
 
-If you use `BLUETOOTH_SCAN` to determine location, remove `android:usesPermissionFlags="neverForLocation"`
+If you use `BLUETOOTH_SCAN` to determine location, modify your AndroidManfiest.xml file to include the following entry:
+
+```xml
+ <uses-permission android:name="android.permission.BLUETOOTH_SCAN" 
+                     tools:remove="android:usesPermissionFlags"
+                     tools:targetApi="s" />
+```
 
 If you use location services in your app, remove `android:maxSdkVersion="30"` from the location permission tags
 


### PR DESCRIPTION
#524 tried to handle manifest merge issue for ble scan on Android 12.

But [RxAndroidBLE](https://github.com/dariuszseweryn/RxAndroidBle) which `flutter_reactive_ble` uses for bluetooth still has permissions on its [AndroidManifest.xml](https://github.com/dariuszseweryn/RxAndroidBle/blob/master/rxandroidble/src/main/AndroidManifest.xml). It causes merge issue when users try to scan bluetooth for `location` since `neverforlocation` already declared on that file.  

To get a scanresult for location Android 12, `neverforlocation` should be manullay removed using `tools:removed` and this PR is to mention it on README.md