### PR TITLE
Enable extended advertising on android

### DIFF
--- a/packages/reactive_ble_mobile/android/build.gradle
+++ b/packages/reactive_ble_mobile/android/build.gradle
@@ -95,7 +95,7 @@ protobuf {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.polidea.rxandroidble2:rxandroidble:1.13.0'
+    implementation 'com.polidea.rxandroidble2:rxandroidble:1.16.0'
     implementation 'com.google.protobuf:protobuf-javalite:3.18.1'
     implementation 'io.reactivex.rxjava2:rxkotlin:2.4.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -75,6 +75,7 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
         return rxBleClient.scanBleDevices(
             ScanSettings.Builder()
                 .setScanMode(scanMode.toScanSettings())
+                .setLegacy(false)
                 .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
                 .setShouldCheckLocationServicesState(requireLocationServicesEnabled)
                 .build(),


### PR DESCRIPTION
RxAndroidBle 1.16.0 now supports enabling extended advertising (https://github.com/dariuszseweryn/RxAndroidBle/commit/4371b7832c1aaf328223f831d92b463dca039e85)
flutter_reactive_ble already supports extended advertising with iOS, so no changes are needed.