### PR TITLE
Read RSSI of connected device

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,7 +30,7 @@ void main() {
     writeWithOutResponse: _ble.writeCharacteristicWithoutResponse,
     subscribeToCharacteristic: _ble.subscribeToCharacteristic,
     logMessage: _bleLogger.addToLog,
-    readRssi: _ble.readRssi,
+    streamRssi: _ble.streamRssi,
   );
   runApp(
     MultiProvider(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -30,6 +30,7 @@ void main() {
     writeWithOutResponse: _ble.writeCharacteristicWithoutResponse,
     subscribeToCharacteristic: _ble.subscribeToCharacteristic,
     logMessage: _bleLogger.addToLog,
+    readRssi: _ble.readRssi,
   );
   runApp(
     MultiProvider(

--- a/example/lib/src/ble/ble_device_interactor.dart
+++ b/example/lib/src/ble/ble_device_interactor.dart
@@ -17,6 +17,7 @@ class BleDeviceInteractor {
     required void Function(String message) logMessage,
     required Stream<List<int>> Function(QualifiedCharacteristic characteristic)
         subscribeToCharacteristic,
+    required this.readRssi,
   })  : _bleDiscoverServices = bleDiscoverServices,
         _readCharacteristic = readCharacteristic,
         _writeWithResponse = writeWithResponse,
@@ -38,6 +39,8 @@ class BleDeviceInteractor {
 
   final Stream<List<int>> Function(QualifiedCharacteristic characteristic)
       _subScribeToCharacteristic;
+
+  final Future<int> Function(String deviceId) readRssi;
 
   final void Function(String message) _logMessage;
 

--- a/example/lib/src/ble/ble_device_interactor.dart
+++ b/example/lib/src/ble/ble_device_interactor.dart
@@ -17,7 +17,7 @@ class BleDeviceInteractor {
     required void Function(String message) logMessage,
     required Stream<List<int>> Function(QualifiedCharacteristic characteristic)
         subscribeToCharacteristic,
-    required this.readRssi,
+    required this.streamRssi,
   })  : _bleDiscoverServices = bleDiscoverServices,
         _readCharacteristic = readCharacteristic,
         _writeWithResponse = writeWithResponse,
@@ -40,7 +40,7 @@ class BleDeviceInteractor {
   final Stream<List<int>> Function(QualifiedCharacteristic characteristic)
       _subScribeToCharacteristic;
 
-  final Future<int> Function(String deviceId) readRssi;
+  final Stream<int> Function(String deviceId) streamRssi;
 
   final void Function(String message) _logMessage;
 

--- a/example/lib/src/ui/device_detail/device_interaction_tab.g.dart
+++ b/example/lib/src/ui/device_detail/device_interaction_tab.g.dart
@@ -13,21 +13,21 @@ abstract class $DeviceInteractionViewModel {
   DeviceConnectionState get connectionStatus;
   BleDeviceConnector get deviceConnector;
   Future<List<DiscoveredService>> Function() get discoverServices;
-  Future<int> Function() get readRssi;
+  Stream<int> Function() get streamRssi;
 
   DeviceInteractionViewModel copyWith({
     String? deviceId,
     DeviceConnectionState? connectionStatus,
     BleDeviceConnector? deviceConnector,
     Future<List<DiscoveredService>> Function()? discoverServices,
-    Future<int> Function()? readRssi,
+    Stream<int> Function()? streamRssi,
   }) =>
       DeviceInteractionViewModel(
         deviceId: deviceId ?? this.deviceId,
         connectionStatus: connectionStatus ?? this.connectionStatus,
         deviceConnector: deviceConnector ?? this.deviceConnector,
         discoverServices: discoverServices ?? this.discoverServices,
-        readRssi: readRssi ?? this.readRssi,
+        streamRssi: streamRssi ?? this.streamRssi,
       );
 
   DeviceInteractionViewModel copyUsing(
@@ -37,7 +37,7 @@ abstract class $DeviceInteractionViewModel {
       this.connectionStatus,
       this.deviceConnector,
       this.discoverServices,
-      this.readRssi,
+      this.streamRssi,
     );
     mutator(change);
     return DeviceInteractionViewModel(
@@ -45,13 +45,13 @@ abstract class $DeviceInteractionViewModel {
       connectionStatus: change.connectionStatus,
       deviceConnector: change.deviceConnector,
       discoverServices: change.discoverServices,
-      readRssi: change.readRssi,
+      streamRssi: change.streamRssi,
     );
   }
 
   @override
   String toString() =>
-      "DeviceInteractionViewModel(deviceId: $deviceId, connectionStatus: $connectionStatus, deviceConnector: $deviceConnector, discoverServices: $discoverServices, readRssi: $readRssi)";
+      "DeviceInteractionViewModel(deviceId: $deviceId, connectionStatus: $connectionStatus, deviceConnector: $deviceConnector, discoverServices: $discoverServices, streamRssi: $streamRssi)";
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
@@ -62,7 +62,7 @@ abstract class $DeviceInteractionViewModel {
       connectionStatus == other.connectionStatus &&
       deviceConnector == other.deviceConnector &&
       const Ignore().equals(discoverServices, other.discoverServices) &&
-      readRssi == other.readRssi;
+      streamRssi == other.streamRssi;
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
@@ -72,7 +72,7 @@ abstract class $DeviceInteractionViewModel {
     result = 37 * result + connectionStatus.hashCode;
     result = 37 * result + deviceConnector.hashCode;
     result = 37 * result + const Ignore().hash(discoverServices);
-    result = 37 * result + readRssi.hashCode;
+    result = 37 * result + streamRssi.hashCode;
     return result;
   }
 }
@@ -83,14 +83,14 @@ class DeviceInteractionViewModel$Change {
     this.connectionStatus,
     this.deviceConnector,
     this.discoverServices,
-    this.readRssi,
+    this.streamRssi,
   );
 
   String deviceId;
   DeviceConnectionState connectionStatus;
   BleDeviceConnector deviceConnector;
   Future<List<DiscoveredService>> Function() discoverServices;
-  Future<int> Function() readRssi;
+  Stream<int> Function() streamRssi;
 }
 
 // ignore: avoid_classes_with_only_static_members
@@ -122,10 +122,10 @@ class DeviceInteractionViewModel$ {
         discoverServicesContainer.copyWith(discoverServices: discoverServices),
   );
 
-  static final readRssi =
-      Lens<DeviceInteractionViewModel, Future<int> Function()>(
-    (readRssiContainer) => readRssiContainer.readRssi,
-    (readRssiContainer, readRssi) =>
-        readRssiContainer.copyWith(readRssi: readRssi),
+  static final streamRssi =
+      Lens<DeviceInteractionViewModel, Stream<int> Function()>(
+    (streamRssiContainer) => streamRssiContainer.streamRssi,
+    (streamRssiContainer, streamRssi) =>
+        streamRssiContainer.copyWith(streamRssi: streamRssi),
   );
 }

--- a/example/lib/src/ui/device_detail/device_interaction_tab.g.dart
+++ b/example/lib/src/ui/device_detail/device_interaction_tab.g.dart
@@ -6,64 +6,126 @@ part of 'device_interaction_tab.dart';
 // FunctionalDataGenerator
 // **************************************************************************
 
-// ignore_for_file: join_return_with_assignment
-// ignore_for_file: avoid_classes_with_only_static_members
-// ignore_for_file: non_constant_identifier_names
-// ignore_for_file: avoid_equals_and_hash_code_on_mutable_classes
 abstract class $DeviceInteractionViewModel {
   const $DeviceInteractionViewModel();
+
   String get deviceId;
   DeviceConnectionState get connectionStatus;
   BleDeviceConnector get deviceConnector;
   Future<List<DiscoveredService>> Function() get discoverServices;
-  DeviceInteractionViewModel copyWith(
-          {String? deviceId,
-          DeviceConnectionState? connectionStatus,
-          BleDeviceConnector? deviceConnector,
-          Future<List<DiscoveredService>> Function()? discoverServices}) =>
+  Future<int> Function() get readRssi;
+
+  DeviceInteractionViewModel copyWith({
+    String? deviceId,
+    DeviceConnectionState? connectionStatus,
+    BleDeviceConnector? deviceConnector,
+    Future<List<DiscoveredService>> Function()? discoverServices,
+    Future<int> Function()? readRssi,
+  }) =>
       DeviceInteractionViewModel(
-          deviceId: deviceId ?? this.deviceId,
-          connectionStatus: connectionStatus ?? this.connectionStatus,
-          deviceConnector: deviceConnector ?? this.deviceConnector,
-          discoverServices: discoverServices ?? this.discoverServices);
+        deviceId: deviceId ?? this.deviceId,
+        connectionStatus: connectionStatus ?? this.connectionStatus,
+        deviceConnector: deviceConnector ?? this.deviceConnector,
+        discoverServices: discoverServices ?? this.discoverServices,
+        readRssi: readRssi ?? this.readRssi,
+      );
+
+  DeviceInteractionViewModel copyUsing(
+      void Function(DeviceInteractionViewModel$Change change) mutator) {
+    final change = DeviceInteractionViewModel$Change._(
+      this.deviceId,
+      this.connectionStatus,
+      this.deviceConnector,
+      this.discoverServices,
+      this.readRssi,
+    );
+    mutator(change);
+    return DeviceInteractionViewModel(
+      deviceId: change.deviceId,
+      connectionStatus: change.connectionStatus,
+      deviceConnector: change.deviceConnector,
+      discoverServices: change.discoverServices,
+      readRssi: change.readRssi,
+    );
+  }
+
   @override
   String toString() =>
-      "DeviceInteractionViewModel(deviceId: $deviceId, connectionStatus: $connectionStatus, deviceConnector: $deviceConnector, discoverServices: $discoverServices)";
+      "DeviceInteractionViewModel(deviceId: $deviceId, connectionStatus: $connectionStatus, deviceConnector: $deviceConnector, discoverServices: $discoverServices, readRssi: $readRssi)";
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) =>
       other is DeviceInteractionViewModel &&
       other.runtimeType == runtimeType &&
       deviceId == other.deviceId &&
       connectionStatus == other.connectionStatus &&
       deviceConnector == other.deviceConnector &&
-      const Ignore().equals(discoverServices, other.discoverServices);
+      const Ignore().equals(discoverServices, other.discoverServices) &&
+      readRssi == other.readRssi;
+
   @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
   int get hashCode {
     var result = 17;
     result = 37 * result + deviceId.hashCode;
     result = 37 * result + connectionStatus.hashCode;
     result = 37 * result + deviceConnector.hashCode;
     result = 37 * result + const Ignore().hash(discoverServices);
+    result = 37 * result + readRssi.hashCode;
     return result;
   }
 }
 
+class DeviceInteractionViewModel$Change {
+  DeviceInteractionViewModel$Change._(
+    this.deviceId,
+    this.connectionStatus,
+    this.deviceConnector,
+    this.discoverServices,
+    this.readRssi,
+  );
+
+  String deviceId;
+  DeviceConnectionState connectionStatus;
+  BleDeviceConnector deviceConnector;
+  Future<List<DiscoveredService>> Function() discoverServices;
+  Future<int> Function() readRssi;
+}
+
+// ignore: avoid_classes_with_only_static_members
 class DeviceInteractionViewModel$ {
   static final deviceId = Lens<DeviceInteractionViewModel, String>(
-      (s_) => s_.deviceId, (s_, deviceId) => s_.copyWith(deviceId: deviceId));
+    (deviceIdContainer) => deviceIdContainer.deviceId,
+    (deviceIdContainer, deviceId) =>
+        deviceIdContainer.copyWith(deviceId: deviceId),
+  );
+
   static final connectionStatus =
       Lens<DeviceInteractionViewModel, DeviceConnectionState>(
-          (s_) => s_.connectionStatus,
-          (s_, connectionStatus) =>
-              s_.copyWith(connectionStatus: connectionStatus));
+    (connectionStatusContainer) => connectionStatusContainer.connectionStatus,
+    (connectionStatusContainer, connectionStatus) =>
+        connectionStatusContainer.copyWith(connectionStatus: connectionStatus),
+  );
+
   static final deviceConnector =
       Lens<DeviceInteractionViewModel, BleDeviceConnector>(
-          (s_) => s_.deviceConnector,
-          (s_, deviceConnector) =>
-              s_.copyWith(deviceConnector: deviceConnector));
+    (deviceConnectorContainer) => deviceConnectorContainer.deviceConnector,
+    (deviceConnectorContainer, deviceConnector) =>
+        deviceConnectorContainer.copyWith(deviceConnector: deviceConnector),
+  );
+
   static final discoverServices = Lens<DeviceInteractionViewModel,
-          Future<List<DiscoveredService>> Function()>(
-      (s_) => s_.discoverServices,
-      (s_, discoverServices) =>
-          s_.copyWith(discoverServices: discoverServices));
+      Future<List<DiscoveredService>> Function()>(
+    (discoverServicesContainer) => discoverServicesContainer.discoverServices,
+    (discoverServicesContainer, discoverServices) =>
+        discoverServicesContainer.copyWith(discoverServices: discoverServices),
+  );
+
+  static final readRssi =
+      Lens<DeviceInteractionViewModel, Future<int> Function()>(
+    (readRssiContainer) => readRssiContainer.readRssi,
+    (readRssiContainer, readRssi) =>
+        readRssiContainer.copyWith(readRssi: readRssi),
+  );
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -411,7 +411,7 @@ packages:
     source: path
     version: "5.0.2"
   reactive_ble_platform_interface:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       path: "../packages/reactive_ble_platform_interface"
       relative: true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -413,9 +413,9 @@ packages:
   reactive_ble_platform_interface:
     dependency: transitive
     description:
-      name: reactive_ble_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../packages/reactive_ble_platform_interface"
+      relative: true
+    source: path
     version: "5.0.2"
   shelf:
     dependency: transitive

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -29,6 +29,8 @@ dependency_overrides:
     path: ../packages/flutter_reactive_ble
   reactive_ble_mobile:
     path: ../packages/reactive_ble_mobile
+  reactive_ble_platform_interface:
+    path: ../packages/reactive_ble_platform_interface
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -309,6 +309,12 @@ class FlutterReactiveBle {
       .clearGattCache(deviceId)
       .then((info) => info.dematerialize());
 
+  /// Reads the RSSI of the of the peripheral with the given device ID. 
+  /// The peripheral must be connected, otherwise a [PlatformException] will be
+  /// thrown
+  Future<int> readRssi(String deviceId) async =>
+      _blePlatform.readRssi(deviceId);
+
   /// Subscribes to updates from the characteristic specified.
   ///
   /// This stream terminates automatically when the device is disconnected.

--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -315,8 +315,10 @@ class FlutterReactiveBle {
   ///
   /// [rssiPeriod] controls the interval at which a new RSSI value will be
   /// returned. Defaults to 1 second.
-  Stream<int> streamRssi(String deviceId,
-          {Duration rssiPeriod = const Duration(seconds: 1)}) =>
+  Stream<int> streamRssi(
+    String deviceId, {
+    Duration rssiPeriod = const Duration(seconds: 1),
+  }) =>
       _blePlatform.streamRssi(deviceId, rssiPeriod);
 
   /// Subscribes to updates from the characteristic specified.

--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -309,11 +309,15 @@ class FlutterReactiveBle {
       .clearGattCache(deviceId)
       .then((info) => info.dematerialize());
 
-  /// Reads the RSSI of the of the peripheral with the given device ID. 
+  /// Streams the RSSI of the of the peripheral with the given device ID.
   /// The peripheral must be connected, otherwise a [PlatformException] will be
   /// thrown
-  Future<int> readRssi(String deviceId) async =>
-      _blePlatform.readRssi(deviceId);
+  ///
+  /// [rssiPeriod] controls the interval at which a new RSSI value will be
+  /// returned. Defaults to 1 second.
+  Stream<int> streamRssi(String deviceId,
+          {Duration rssiPeriod = const Duration(seconds: 1)}) =>
+      _blePlatform.streamRssi(deviceId, rssiPeriod);
 
   /// Subscribes to updates from the characteristic specified.
   ///

--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -21,8 +21,10 @@ dependencies:
     sdk: flutter
   functional_data: ^1.0.0
   meta: ^1.3.0
-  reactive_ble_mobile: ^5.0.2
-  reactive_ble_platform_interface: ^5.0.2
+  reactive_ble_mobile:
+    path: ../reactive_ble_mobile
+  reactive_ble_platform_interface: 
+    path: ../reactive_ble_platform_interface
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_lints: ^1.0.4

--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -21,10 +21,8 @@ dependencies:
     sdk: flutter
   functional_data: ^1.0.0
   meta: ^1.3.0
-  reactive_ble_mobile:
-    path: ../reactive_ble_mobile
-  reactive_ble_platform_interface: 
-    path: ../reactive_ble_platform_interface
+  reactive_ble_mobile: ^5.0.2
+  reactive_ble_platform_interface: ^5.0.2
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_lints: ^1.0.4

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
@@ -275,7 +275,7 @@ class PluginController {
         bleClient.readRssi(args.deviceId)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe({ rssi ->
-                    val info = protoConverter.convertReadRssiResult(rssi);
+                    val info = protoConverter.convertReadRssiResult(rssi)
                     result.success(info.toByteArray())
                 }, { error ->
                     result.error("read_rssi_error", error.message, null)

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
@@ -36,7 +36,8 @@ class PluginController {
             "stopNotifications" to this::stopNotifications,
             "negotiateMtuSize" to this::negotiateMtuSize,
             "requestConnectionPriority" to this::requestConnectionPriority,
-            "discoverServices" to this::discoverServices
+            "discoverServices" to this::discoverServices,
+            "readRssi" to this::readRssi,
     )
 
     lateinit var bleClient: com.signify.hue.flutterreactiveble.ble.BleClient
@@ -264,6 +265,20 @@ class PluginController {
                     result.success(protoConverter.convertDiscoverServicesInfo(request.deviceId, discoverResult).toByteArray())
                 }, {
                     throwable -> result.error("service_discovery_failure", throwable.message, null)
+                })
+                .discard()
+    }
+
+    private fun readRssi(call: MethodCall, result: Result) {
+        val args = pb.ClearGattCacheRequest.parseFrom(call.arguments as ByteArray)
+
+        bleClient.readRssi(args.deviceId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ rssi ->
+                    val info = protoConverter.convertReadRssiResult(rssi);
+                    result.success(info.toByteArray())
+                }, { error ->
+                    result.error("read_rssi_error", error.message, null)
                 })
                 .discard()
     }

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/BleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/BleClient.kt
@@ -38,4 +38,5 @@ interface BleClient {
     fun observeBleStatus(): Observable<BleStatus>
     fun requestConnectionPriority(deviceId: String, priority: ConnectionPriority):
             Single<RequestConnectionPriorityResult>
+    fun readRssi(deviceId: String): Single<Int>
 }

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/DeviceConnector.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/DeviceConnector.kt
@@ -184,4 +184,14 @@ internal class DeviceConnector(
                         queue.firstOrNull() == deviceId || !queue.contains(deviceId)
                     }
                     .takeUntil { it.isEmpty() || it.first() == deviceId }
+
+    /**
+     * Reads the current RSSI value of the device
+     */
+    internal fun readRssi(): Single<Int> = currentConnection?.let { connection ->
+        when (connection) {
+            is EstablishedConnection -> connection.rxConnection.readRssi()
+            is EstablishConnectionFailure -> Single.error(Throwable(connection.errorMessage))
+        }
+    } ?: Single.error(IllegalStateException("Connection is not established"))
 }

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -330,6 +330,11 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
             }
         }.first(RequestConnectionPriorityFailed(deviceId, "Unknown failure"))
 
+    override fun readRssi(deviceId: String): Single<Int> =
+            activeConnections[deviceId]?.let(DeviceConnector::readRssi)
+                    ?: Single.error(IllegalStateException("Device is not connected"))
+
+
     // enable this for extra debug output on the android stack
     private fun enableDebugLogging() = RxBleClient
         .updateLogOptions(

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -334,7 +334,6 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
             activeConnections[deviceId]?.let(DeviceConnector::readRssi)
                     ?: Single.error(IllegalStateException("Device is not connected"))
 
-
     // enable this for extra debug output on the android stack
     private fun enableDebugLogging() = RxBleClient
         .updateLogOptions(

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverter.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ProtobufMessageConverter.kt
@@ -173,6 +173,12 @@ class ProtobufMessageConverter {
                 .build()
     }
 
+    fun convertReadRssiResult(rssi: Int): pb.ReadRssiResult {
+        return pb.ReadRssiResult.newBuilder()
+                .setRssi(rssi)
+                .build()
+    }
+
     private fun fromBluetoothGattService(gattService: BluetoothGattService): pb.DiscoveredService {
         return pb.DiscoveredService.newBuilder()
                 .setServiceUuid(createUuidFromParcelUuid(gattService.uuid))

--- a/packages/reactive_ble_mobile/ios/Classes/BleData/bledata.pb.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/BleData/bledata.pb.swift
@@ -587,6 +587,30 @@ struct DiscoveredCharacteristic {
   fileprivate var _serviceID: Uuid? = nil
 }
 
+struct ReadRssiRequest {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var deviceID: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+struct ReadRssiResult {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var rssi: Int32 = 0
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
 struct Uuid {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -612,6 +636,39 @@ struct GenericFailure {
 
   init() {}
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+extension ScanForDevicesRequest: @unchecked Sendable {}
+extension DeviceScanInfo: @unchecked Sendable {}
+extension ConnectToDeviceRequest: @unchecked Sendable {}
+extension DeviceInfo: @unchecked Sendable {}
+extension DisconnectFromDeviceRequest: @unchecked Sendable {}
+extension ClearGattCacheRequest: @unchecked Sendable {}
+extension ClearGattCacheInfo: @unchecked Sendable {}
+extension NotifyCharacteristicRequest: @unchecked Sendable {}
+extension NotifyNoMoreCharacteristicRequest: @unchecked Sendable {}
+extension ReadCharacteristicRequest: @unchecked Sendable {}
+extension CharacteristicValueInfo: @unchecked Sendable {}
+extension WriteCharacteristicRequest: @unchecked Sendable {}
+extension WriteCharacteristicInfo: @unchecked Sendable {}
+extension NegotiateMtuRequest: @unchecked Sendable {}
+extension NegotiateMtuInfo: @unchecked Sendable {}
+extension BleStatusInfo: @unchecked Sendable {}
+extension ChangeConnectionPriorityRequest: @unchecked Sendable {}
+extension ChangeConnectionPriorityInfo: @unchecked Sendable {}
+extension CharacteristicAddress: @unchecked Sendable {}
+extension ServiceDataEntry: @unchecked Sendable {}
+extension ServicesWithCharacteristics: @unchecked Sendable {}
+extension ServiceWithCharacteristics: @unchecked Sendable {}
+extension DiscoverServicesRequest: @unchecked Sendable {}
+extension DiscoverServicesInfo: @unchecked Sendable {}
+extension DiscoveredService: @unchecked Sendable {}
+extension DiscoveredCharacteristic: @unchecked Sendable {}
+extension ReadRssiRequest: @unchecked Sendable {}
+extension ReadRssiResult: @unchecked Sendable {}
+extension Uuid: @unchecked Sendable {}
+extension GenericFailure: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
@@ -690,15 +747,19 @@ extension DeviceScanInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.id.isEmpty {
       try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
     }
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 2)
     }
-    if let v = self._failure {
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     if !self.serviceData.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.serviceData, fieldNumber: 4)
     }
@@ -750,12 +811,16 @@ extension ConnectToDeviceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.deviceID.isEmpty {
       try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 1)
     }
-    if let v = self._servicesWithCharacteristicsToDiscover {
+    try { if let v = self._servicesWithCharacteristicsToDiscover {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.timeoutInMs != 0 {
       try visitor.visitSingularInt32Field(value: self.timeoutInMs, fieldNumber: 3)
     }
@@ -794,15 +859,19 @@ extension DeviceInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementatio
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.id.isEmpty {
       try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
     }
     if self.connectionState != 0 {
       try visitor.visitSingularInt32Field(value: self.connectionState, fieldNumber: 2)
     }
-    if let v = self._failure {
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -898,9 +967,13 @@ extension ClearGattCacheInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImple
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._failure {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -930,9 +1003,13 @@ extension NotifyCharacteristicRequest: SwiftProtobuf.Message, SwiftProtobuf._Mes
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -962,9 +1039,13 @@ extension NotifyNoMoreCharacteristicRequest: SwiftProtobuf.Message, SwiftProtobu
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -994,9 +1075,13 @@ extension ReadCharacteristicRequest: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1030,15 +1115,19 @@ extension CharacteristicValueInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.value.isEmpty {
       try visitor.visitSingularBytesField(value: self.value, fieldNumber: 2)
     }
-    if let v = self._failure {
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1072,9 +1161,13 @@ extension WriteCharacteristicRequest: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.value.isEmpty {
       try visitor.visitSingularBytesField(value: self.value, fieldNumber: 2)
     }
@@ -1110,12 +1203,16 @@ extension WriteCharacteristicInfo: SwiftProtobuf.Message, SwiftProtobuf._Message
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristic {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristic {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._failure {
+    } }()
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1188,15 +1285,19 @@ extension NegotiateMtuInfo: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.deviceID.isEmpty {
       try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 1)
     }
     if self.mtuSize != 0 {
       try visitor.visitSingularInt32Field(value: self.mtuSize, fieldNumber: 2)
     }
-    if let v = self._failure {
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1300,12 +1401,16 @@ extension ChangeConnectionPriorityInfo: SwiftProtobuf.Message, SwiftProtobuf._Me
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.deviceID.isEmpty {
       try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 1)
     }
-    if let v = self._failure {
+    try { if let v = self._failure {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1340,15 +1445,19 @@ extension CharacteristicAddress: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.deviceID.isEmpty {
       try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 1)
     }
-    if let v = self._serviceUuid {
+    try { if let v = self._serviceUuid {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
-    if let v = self._characteristicUuid {
+    } }()
+    try { if let v = self._characteristicUuid {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
-    }
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -1382,9 +1491,13 @@ extension ServiceDataEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._serviceUuid {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._serviceUuid {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.data.isEmpty {
       try visitor.visitSingularBytesField(value: self.data, fieldNumber: 2)
     }
@@ -1452,9 +1565,13 @@ extension ServiceWithCharacteristics: SwiftProtobuf.Message, SwiftProtobuf._Mess
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._serviceID {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._serviceID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.characteristics.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.characteristics, fieldNumber: 2)
     }
@@ -1564,9 +1681,13 @@ extension DiscoveredService: SwiftProtobuf.Message, SwiftProtobuf._MessageImplem
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._serviceUuid {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._serviceUuid {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
+    } }()
     if !self.characteristicUuids.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.characteristicUuids, fieldNumber: 2)
     }
@@ -1620,12 +1741,16 @@ extension DiscoveredCharacteristic: SwiftProtobuf.Message, SwiftProtobuf._Messag
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    if let v = self._characteristicID {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
+    try { if let v = self._characteristicID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 1)
-    }
-    if let v = self._serviceID {
+    } }()
+    try { if let v = self._serviceID {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    }
+    } }()
     if self.isReadable != false {
       try visitor.visitSingularBoolField(value: self.isReadable, fieldNumber: 3)
     }
@@ -1652,6 +1777,70 @@ extension DiscoveredCharacteristic: SwiftProtobuf.Message, SwiftProtobuf._Messag
     if lhs.isWritableWithoutResponse != rhs.isWritableWithoutResponse {return false}
     if lhs.isNotifiable != rhs.isNotifiable {return false}
     if lhs.isIndicatable != rhs.isIndicatable {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension ReadRssiRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = "ReadRssiRequest"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "deviceId"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.deviceID) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.deviceID.isEmpty {
+      try visitor.visitSingularStringField(value: self.deviceID, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: ReadRssiRequest, rhs: ReadRssiRequest) -> Bool {
+    if lhs.deviceID != rhs.deviceID {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension ReadRssiResult: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = "ReadRssiResult"
+  static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+    1: .same(proto: "rssi"),
+  ]
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularInt32Field(value: &self.rssi) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.rssi != 0 {
+      try visitor.visitSingularInt32Field(value: self.rssi, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: ReadRssiResult, rhs: ReadRssiResult) -> Bool {
+    if lhs.rssi != rhs.rssi {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/reactive_ble_mobile/ios/Classes/Plugin/SwiftReactiveBlePlugin.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/Plugin/SwiftReactiveBlePlugin.swift
@@ -138,6 +138,9 @@ public class SwiftReactiveBlePlugin: NSObject, FlutterPlugin {
         AnyPlatformMethod(UnaryPlatformMethod(name: "negotiateMtuSize") { (name, context, args: NegotiateMtuRequest, completion) in
             context.reportMaximumWriteValueLength(name: name, args: args, completion: completion)
         }),
+        AnyPlatformMethod(UnaryPlatformMethod(name: "readRssi") { (name, context, args: ReadRssiRequest, completion) in
+            context.readRssi(name: name, args: args, completion: completion)
+        })
     ])
 
     public func handle(_ call: FlutterMethodCall, result completion: @escaping FlutterResult) {

--- a/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/PeripheralDelegate.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/PeripheralDelegate.swift
@@ -7,25 +7,29 @@ final class PeripheralDelegate: NSObject, CBPeripheralDelegate {
     typealias CharacteristicNotificationStateUpdateHandler = (CBCharacteristic, Error?) -> Void
     typealias CharacteristicValueUpdateHandler = (CBCharacteristic, Error?) -> Void
     typealias CharacteristicValueWriteHandler = (CBCharacteristic, Error?) -> Void
+    typealias ReadRssiHandler = (CBPeripheral, Int, Error?) -> Void
 
     private let onServicesDiscovery: ServicesDiscoveryHandler
     private let onCharacteristicsDiscovery: CharacteristicsDiscoverHandler
     private let onCharacteristicNotificationStateUpdate: CharacteristicNotificationStateUpdateHandler
     private let onCharacteristicValueUpdate: CharacteristicValueUpdateHandler
     private let onCharacteristicValueWrite: CharacteristicValueWriteHandler
+    private let onReadRssi: ReadRssiHandler
 
     init(
         onServicesDiscovery: @escaping ServicesDiscoveryHandler,
         onCharacteristicsDiscovery: @escaping CharacteristicsDiscoverHandler,
         onCharacteristicNotificationStateUpdate: @escaping CharacteristicNotificationStateUpdateHandler,
         onCharacteristicValueUpdate: @escaping CharacteristicValueUpdateHandler,
-        onCharacteristicValueWrite: @escaping CharacteristicValueWriteHandler
+        onCharacteristicValueWrite: @escaping CharacteristicValueWriteHandler,
+        onReadRssi: @escaping ReadRssiHandler
     ) {
         self.onServicesDiscovery = onServicesDiscovery
         self.onCharacteristicsDiscovery = onCharacteristicsDiscovery
         self.onCharacteristicNotificationStateUpdate = onCharacteristicNotificationStateUpdate
         self.onCharacteristicValueUpdate = onCharacteristicValueUpdate
         self.onCharacteristicValueWrite = onCharacteristicValueWrite
+        self.onReadRssi = onReadRssi
     }
 
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
@@ -46,5 +50,9 @@ final class PeripheralDelegate: NSObject, CBPeripheralDelegate {
 
     func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         onCharacteristicValueWrite(characteristic, error)
+    }
+    
+    func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        onReadRssi(peripheral, RSSI.intValue, error)
     }
 }

--- a/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Tasks/ReadRssi/ReadRssiTaskController.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Tasks/ReadRssi/ReadRssiTaskController.swift
@@ -1,0 +1,42 @@
+import CoreBluetooth
+
+struct ReadRssiTaskController: PeripheralTaskController {
+    typealias TaskSpec = ReadRssiTaskSpec
+    
+    private let task: SubjectTask
+    
+    init(_ task: SubjectTask) {
+        self.task = task
+    }
+    
+    func start(peripheral: CBPeripheral) -> SubjectTask {
+        // error if not connected
+        guard peripheral.state == .connected
+        else {
+            return task.with(
+                state: task.state.finished(
+                    .failure(PluginError.internalInconcictency(details: nil))
+                )
+            )
+        }
+        
+        peripheral.readRSSI()
+        
+        return task.with(state: task.state.processing(.readingRssi))
+    }
+    
+    func cancel(error: Error) -> SubjectTask {
+        return task
+            .with(state: task.state.finished(.failure(error)))
+    }
+    
+    func handleReadRssi(rssi: Int, error: Error?) -> SubjectTask {
+        if let error = error {
+            return task
+                .with(state: task.state.finished(.failure(error)))
+        } else {
+            return task
+                .with(state: task.state.finished(.success(rssi)))
+        }
+    }
+}

--- a/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Tasks/ReadRssi/ReadRssiTaskSpec.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Tasks/ReadRssi/ReadRssiTaskSpec.swift
@@ -1,0 +1,17 @@
+struct ReadRssiTaskSpec: PeripheralTaskSpec {
+    typealias Key = PeripheralID
+    
+    struct Params {}
+    
+    enum Stage {
+        case readingRssi
+    }
+    
+    typealias Result = Failable<Int>
+    
+    static let tag = "READ RSSI"
+    
+    static func isMember(_ key: Key, of group: PeripheralID) -> Bool {
+        return key == group
+    }
+}

--- a/packages/reactive_ble_mobile/lib/src/converter/args_to_protubuf_converter.dart
+++ b/packages/reactive_ble_mobile/lib/src/converter/args_to_protubuf_converter.dart
@@ -47,6 +47,8 @@ abstract class ArgsToProtobufConverter {
   pb.ClearGattCacheRequest createClearGattCacheRequest(String deviceId);
 
   pb.DiscoverServicesRequest createDiscoverServicesRequest(String deviceId);
+
+  pb.ReadRssiRequest createReadRssiRequest(String deviceId);
 }
 
 class ArgsToProtobufConverterImpl implements ArgsToProtobufConverter {
@@ -196,6 +198,12 @@ class ArgsToProtobufConverterImpl implements ArgsToProtobufConverter {
   @override
   pb.DiscoverServicesRequest createDiscoverServicesRequest(String deviceId) {
     final args = pb.DiscoverServicesRequest()..deviceId = deviceId;
+    return args;
+  }
+
+  @override
+  pb.ReadRssiRequest createReadRssiRequest(String deviceId) {
+    final args = pb.ReadRssiRequest()..deviceId = deviceId;
     return args;
   }
 }

--- a/packages/reactive_ble_mobile/lib/src/converter/protobuf_converter.dart
+++ b/packages/reactive_ble_mobile/lib/src/converter/protobuf_converter.dart
@@ -26,6 +26,8 @@ abstract class ProtobufConverter {
       pb.NegotiateMtuInfo.fromBuffer(data).mtuSize;
 
   List<DiscoveredService> discoveredServicesFrom(List<int> data);
+
+  int readRssiResultFrom(List<int> data);
 }
 
 class ProtobufConverterImpl implements ProtobufConverter {
@@ -195,6 +197,10 @@ class ProtobufConverterImpl implements ProtobufConverter {
     final message = pb.DiscoverServicesInfo.fromBuffer(data);
     return message.services.map(_convertService).toList(growable: false);
   }
+
+  @override
+  int readRssiResultFrom(List<int> data) =>
+      pb.ReadRssiResult.fromBuffer(data).rssi;
 
   DiscoveredService _convertService(pb.DiscoveredService service) =>
       DiscoveredService(

--- a/packages/reactive_ble_mobile/lib/src/generated/bledata.pb.dart
+++ b/packages/reactive_ble_mobile/lib/src/generated/bledata.pb.dart
@@ -2482,6 +2482,134 @@ class DiscoveredCharacteristic extends $pb.GeneratedMessage {
   void clearIsIndicatable() => clearField(7);
 }
 
+class ReadRssiRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ReadRssiRequest',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'deviceId',
+        protoName: 'deviceId')
+    ..hasRequiredFields = false;
+
+  ReadRssiRequest._() : super();
+  factory ReadRssiRequest({
+    $core.String? deviceId,
+  }) {
+    final _result = create();
+    if (deviceId != null) {
+      _result.deviceId = deviceId;
+    }
+    return _result;
+  }
+  factory ReadRssiRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReadRssiRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ReadRssiRequest clone() => ReadRssiRequest()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReadRssiRequest copyWith(void Function(ReadRssiRequest) updates) =>
+      super.copyWith((message) => updates(message as ReadRssiRequest))
+          as ReadRssiRequest; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiRequest create() => ReadRssiRequest._();
+  ReadRssiRequest createEmptyInstance() => create();
+  static $pb.PbList<ReadRssiRequest> createRepeated() =>
+      $pb.PbList<ReadRssiRequest>();
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ReadRssiRequest>(create);
+  static ReadRssiRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get deviceId => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set deviceId($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasDeviceId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDeviceId() => clearField(1);
+}
+
+class ReadRssiResult extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ReadRssiResult',
+      createEmptyInstance: create)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'rssi',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  ReadRssiResult._() : super();
+  factory ReadRssiResult({
+    $core.int? rssi,
+  }) {
+    final _result = create();
+    if (rssi != null) {
+      _result.rssi = rssi;
+    }
+    return _result;
+  }
+  factory ReadRssiResult.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ReadRssiResult.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  ReadRssiResult clone() => ReadRssiResult()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ReadRssiResult copyWith(void Function(ReadRssiResult) updates) =>
+      super.copyWith((message) => updates(message as ReadRssiResult))
+          as ReadRssiResult; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiResult create() => ReadRssiResult._();
+  ReadRssiResult createEmptyInstance() => create();
+  static $pb.PbList<ReadRssiResult> createRepeated() =>
+      $pb.PbList<ReadRssiResult>();
+  @$core.pragma('dart2js:noInline')
+  static ReadRssiResult getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ReadRssiResult>(create);
+  static ReadRssiResult? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get rssi => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set rssi($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasRssi() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRssi() => clearField(1);
+}
+
 class Uuid extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(
       const $core.bool.fromEnvironment('protobuf.omit_message_names')

--- a/packages/reactive_ble_mobile/lib/src/generated/bledata.pbenum.dart
+++ b/packages/reactive_ble_mobile/lib/src/generated/bledata.pbenum.dart
@@ -1,0 +1,7 @@
+///
+//  Generated code. Do not modify.
+//  source: bledata.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+

--- a/packages/reactive_ble_mobile/lib/src/generated/bledata.pbjson.dart
+++ b/packages/reactive_ble_mobile/lib/src/generated/bledata.pbjson.dart
@@ -1,0 +1,346 @@
+///
+//  Generated code. Do not modify.
+//  source: bledata.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+@$core.Deprecated('Use scanForDevicesRequestDescriptor instead')
+const ScanForDevicesRequest$json = const {
+  '1': 'ScanForDevicesRequest',
+  '2': const [
+    const {'1': 'serviceUuids', '3': 1, '4': 3, '5': 11, '6': '.Uuid', '10': 'serviceUuids'},
+    const {'1': 'scanMode', '3': 2, '4': 1, '5': 5, '10': 'scanMode'},
+    const {'1': 'requireLocationServicesEnabled', '3': 3, '4': 1, '5': 8, '10': 'requireLocationServicesEnabled'},
+  ],
+};
+
+/// Descriptor for `ScanForDevicesRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List scanForDevicesRequestDescriptor = $convert.base64Decode('ChVTY2FuRm9yRGV2aWNlc1JlcXVlc3QSKQoMc2VydmljZVV1aWRzGAEgAygLMgUuVXVpZFIMc2VydmljZVV1aWRzEhoKCHNjYW5Nb2RlGAIgASgFUghzY2FuTW9kZRJGCh5yZXF1aXJlTG9jYXRpb25TZXJ2aWNlc0VuYWJsZWQYAyABKAhSHnJlcXVpcmVMb2NhdGlvblNlcnZpY2VzRW5hYmxlZA==');
+@$core.Deprecated('Use deviceScanInfoDescriptor instead')
+const DeviceScanInfo$json = const {
+  '1': 'DeviceScanInfo',
+  '2': const [
+    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    const {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'failure', '3': 3, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+    const {'1': 'serviceData', '3': 4, '4': 3, '5': 11, '6': '.ServiceDataEntry', '10': 'serviceData'},
+    const {'1': 'manufacturerData', '3': 6, '4': 1, '5': 12, '10': 'manufacturerData'},
+    const {'1': 'serviceUuids', '3': 7, '4': 3, '5': 11, '6': '.Uuid', '10': 'serviceUuids'},
+    const {'1': 'rssi', '3': 5, '4': 1, '5': 5, '10': 'rssi'},
+  ],
+};
+
+/// Descriptor for `DeviceScanInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List deviceScanInfoDescriptor = $convert.base64Decode('Cg5EZXZpY2VTY2FuSW5mbxIOCgJpZBgBIAEoCVICaWQSEgoEbmFtZRgCIAEoCVIEbmFtZRIpCgdmYWlsdXJlGAMgASgLMg8uR2VuZXJpY0ZhaWx1cmVSB2ZhaWx1cmUSMwoLc2VydmljZURhdGEYBCADKAsyES5TZXJ2aWNlRGF0YUVudHJ5UgtzZXJ2aWNlRGF0YRIqChBtYW51ZmFjdHVyZXJEYXRhGAYgASgMUhBtYW51ZmFjdHVyZXJEYXRhEikKDHNlcnZpY2VVdWlkcxgHIAMoCzIFLlV1aWRSDHNlcnZpY2VVdWlkcxISCgRyc3NpGAUgASgFUgRyc3Np');
+@$core.Deprecated('Use connectToDeviceRequestDescriptor instead')
+const ConnectToDeviceRequest$json = const {
+  '1': 'ConnectToDeviceRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'servicesWithCharacteristicsToDiscover', '3': 2, '4': 1, '5': 11, '6': '.ServicesWithCharacteristics', '10': 'servicesWithCharacteristicsToDiscover'},
+    const {'1': 'timeoutInMs', '3': 3, '4': 1, '5': 5, '10': 'timeoutInMs'},
+  ],
+};
+
+/// Descriptor for `ConnectToDeviceRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List connectToDeviceRequestDescriptor = $convert.base64Decode('ChZDb25uZWN0VG9EZXZpY2VSZXF1ZXN0EhoKCGRldmljZUlkGAEgASgJUghkZXZpY2VJZBJyCiVzZXJ2aWNlc1dpdGhDaGFyYWN0ZXJpc3RpY3NUb0Rpc2NvdmVyGAIgASgLMhwuU2VydmljZXNXaXRoQ2hhcmFjdGVyaXN0aWNzUiVzZXJ2aWNlc1dpdGhDaGFyYWN0ZXJpc3RpY3NUb0Rpc2NvdmVyEiAKC3RpbWVvdXRJbk1zGAMgASgFUgt0aW1lb3V0SW5Ncw==');
+@$core.Deprecated('Use deviceInfoDescriptor instead')
+const DeviceInfo$json = const {
+  '1': 'DeviceInfo',
+  '2': const [
+    const {'1': 'id', '3': 1, '4': 1, '5': 9, '10': 'id'},
+    const {'1': 'connectionState', '3': 2, '4': 1, '5': 5, '10': 'connectionState'},
+    const {'1': 'failure', '3': 3, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `DeviceInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List deviceInfoDescriptor = $convert.base64Decode('CgpEZXZpY2VJbmZvEg4KAmlkGAEgASgJUgJpZBIoCg9jb25uZWN0aW9uU3RhdGUYAiABKAVSD2Nvbm5lY3Rpb25TdGF0ZRIpCgdmYWlsdXJlGAMgASgLMg8uR2VuZXJpY0ZhaWx1cmVSB2ZhaWx1cmU=');
+@$core.Deprecated('Use disconnectFromDeviceRequestDescriptor instead')
+const DisconnectFromDeviceRequest$json = const {
+  '1': 'DisconnectFromDeviceRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+  ],
+};
+
+/// Descriptor for `DisconnectFromDeviceRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List disconnectFromDeviceRequestDescriptor = $convert.base64Decode('ChtEaXNjb25uZWN0RnJvbURldmljZVJlcXVlc3QSGgoIZGV2aWNlSWQYASABKAlSCGRldmljZUlk');
+@$core.Deprecated('Use clearGattCacheRequestDescriptor instead')
+const ClearGattCacheRequest$json = const {
+  '1': 'ClearGattCacheRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+  ],
+};
+
+/// Descriptor for `ClearGattCacheRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List clearGattCacheRequestDescriptor = $convert.base64Decode('ChVDbGVhckdhdHRDYWNoZVJlcXVlc3QSGgoIZGV2aWNlSWQYASABKAlSCGRldmljZUlk');
+@$core.Deprecated('Use clearGattCacheInfoDescriptor instead')
+const ClearGattCacheInfo$json = const {
+  '1': 'ClearGattCacheInfo',
+  '2': const [
+    const {'1': 'failure', '3': 1, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `ClearGattCacheInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List clearGattCacheInfoDescriptor = $convert.base64Decode('ChJDbGVhckdhdHRDYWNoZUluZm8SKQoHZmFpbHVyZRgBIAEoCzIPLkdlbmVyaWNGYWlsdXJlUgdmYWlsdXJl');
+@$core.Deprecated('Use notifyCharacteristicRequestDescriptor instead')
+const NotifyCharacteristicRequest$json = const {
+  '1': 'NotifyCharacteristicRequest',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+  ],
+};
+
+/// Descriptor for `NotifyCharacteristicRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List notifyCharacteristicRequestDescriptor = $convert.base64Decode('ChtOb3RpZnlDaGFyYWN0ZXJpc3RpY1JlcXVlc3QSPgoOY2hhcmFjdGVyaXN0aWMYASABKAsyFi5DaGFyYWN0ZXJpc3RpY0FkZHJlc3NSDmNoYXJhY3RlcmlzdGlj');
+@$core.Deprecated('Use notifyNoMoreCharacteristicRequestDescriptor instead')
+const NotifyNoMoreCharacteristicRequest$json = const {
+  '1': 'NotifyNoMoreCharacteristicRequest',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+  ],
+};
+
+/// Descriptor for `NotifyNoMoreCharacteristicRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List notifyNoMoreCharacteristicRequestDescriptor = $convert.base64Decode('CiFOb3RpZnlOb01vcmVDaGFyYWN0ZXJpc3RpY1JlcXVlc3QSPgoOY2hhcmFjdGVyaXN0aWMYASABKAsyFi5DaGFyYWN0ZXJpc3RpY0FkZHJlc3NSDmNoYXJhY3RlcmlzdGlj');
+@$core.Deprecated('Use readCharacteristicRequestDescriptor instead')
+const ReadCharacteristicRequest$json = const {
+  '1': 'ReadCharacteristicRequest',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+  ],
+};
+
+/// Descriptor for `ReadCharacteristicRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List readCharacteristicRequestDescriptor = $convert.base64Decode('ChlSZWFkQ2hhcmFjdGVyaXN0aWNSZXF1ZXN0Ej4KDmNoYXJhY3RlcmlzdGljGAEgASgLMhYuQ2hhcmFjdGVyaXN0aWNBZGRyZXNzUg5jaGFyYWN0ZXJpc3RpYw==');
+@$core.Deprecated('Use characteristicValueInfoDescriptor instead')
+const CharacteristicValueInfo$json = const {
+  '1': 'CharacteristicValueInfo',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 12, '10': 'value'},
+    const {'1': 'failure', '3': 3, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `CharacteristicValueInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List characteristicValueInfoDescriptor = $convert.base64Decode('ChdDaGFyYWN0ZXJpc3RpY1ZhbHVlSW5mbxI+Cg5jaGFyYWN0ZXJpc3RpYxgBIAEoCzIWLkNoYXJhY3RlcmlzdGljQWRkcmVzc1IOY2hhcmFjdGVyaXN0aWMSFAoFdmFsdWUYAiABKAxSBXZhbHVlEikKB2ZhaWx1cmUYAyABKAsyDy5HZW5lcmljRmFpbHVyZVIHZmFpbHVyZQ==');
+@$core.Deprecated('Use writeCharacteristicRequestDescriptor instead')
+const WriteCharacteristicRequest$json = const {
+  '1': 'WriteCharacteristicRequest',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `WriteCharacteristicRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List writeCharacteristicRequestDescriptor = $convert.base64Decode('ChpXcml0ZUNoYXJhY3RlcmlzdGljUmVxdWVzdBI+Cg5jaGFyYWN0ZXJpc3RpYxgBIAEoCzIWLkNoYXJhY3RlcmlzdGljQWRkcmVzc1IOY2hhcmFjdGVyaXN0aWMSFAoFdmFsdWUYAiABKAxSBXZhbHVl');
+@$core.Deprecated('Use writeCharacteristicInfoDescriptor instead')
+const WriteCharacteristicInfo$json = const {
+  '1': 'WriteCharacteristicInfo',
+  '2': const [
+    const {'1': 'characteristic', '3': 1, '4': 1, '5': 11, '6': '.CharacteristicAddress', '10': 'characteristic'},
+    const {'1': 'failure', '3': 3, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `WriteCharacteristicInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List writeCharacteristicInfoDescriptor = $convert.base64Decode('ChdXcml0ZUNoYXJhY3RlcmlzdGljSW5mbxI+Cg5jaGFyYWN0ZXJpc3RpYxgBIAEoCzIWLkNoYXJhY3RlcmlzdGljQWRkcmVzc1IOY2hhcmFjdGVyaXN0aWMSKQoHZmFpbHVyZRgDIAEoCzIPLkdlbmVyaWNGYWlsdXJlUgdmYWlsdXJl');
+@$core.Deprecated('Use negotiateMtuRequestDescriptor instead')
+const NegotiateMtuRequest$json = const {
+  '1': 'NegotiateMtuRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'mtuSize', '3': 2, '4': 1, '5': 5, '10': 'mtuSize'},
+  ],
+};
+
+/// Descriptor for `NegotiateMtuRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List negotiateMtuRequestDescriptor = $convert.base64Decode('ChNOZWdvdGlhdGVNdHVSZXF1ZXN0EhoKCGRldmljZUlkGAEgASgJUghkZXZpY2VJZBIYCgdtdHVTaXplGAIgASgFUgdtdHVTaXpl');
+@$core.Deprecated('Use negotiateMtuInfoDescriptor instead')
+const NegotiateMtuInfo$json = const {
+  '1': 'NegotiateMtuInfo',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'mtuSize', '3': 2, '4': 1, '5': 5, '10': 'mtuSize'},
+    const {'1': 'failure', '3': 3, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `NegotiateMtuInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List negotiateMtuInfoDescriptor = $convert.base64Decode('ChBOZWdvdGlhdGVNdHVJbmZvEhoKCGRldmljZUlkGAEgASgJUghkZXZpY2VJZBIYCgdtdHVTaXplGAIgASgFUgdtdHVTaXplEikKB2ZhaWx1cmUYAyABKAsyDy5HZW5lcmljRmFpbHVyZVIHZmFpbHVyZQ==');
+@$core.Deprecated('Use bleStatusInfoDescriptor instead')
+const BleStatusInfo$json = const {
+  '1': 'BleStatusInfo',
+  '2': const [
+    const {'1': 'status', '3': 1, '4': 1, '5': 5, '10': 'status'},
+  ],
+};
+
+/// Descriptor for `BleStatusInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List bleStatusInfoDescriptor = $convert.base64Decode('Cg1CbGVTdGF0dXNJbmZvEhYKBnN0YXR1cxgBIAEoBVIGc3RhdHVz');
+@$core.Deprecated('Use changeConnectionPriorityRequestDescriptor instead')
+const ChangeConnectionPriorityRequest$json = const {
+  '1': 'ChangeConnectionPriorityRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'priority', '3': 2, '4': 1, '5': 5, '10': 'priority'},
+  ],
+};
+
+/// Descriptor for `ChangeConnectionPriorityRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List changeConnectionPriorityRequestDescriptor = $convert.base64Decode('Ch9DaGFuZ2VDb25uZWN0aW9uUHJpb3JpdHlSZXF1ZXN0EhoKCGRldmljZUlkGAEgASgJUghkZXZpY2VJZBIaCghwcmlvcml0eRgCIAEoBVIIcHJpb3JpdHk=');
+@$core.Deprecated('Use changeConnectionPriorityInfoDescriptor instead')
+const ChangeConnectionPriorityInfo$json = const {
+  '1': 'ChangeConnectionPriorityInfo',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'failure', '3': 2, '4': 1, '5': 11, '6': '.GenericFailure', '10': 'failure'},
+  ],
+};
+
+/// Descriptor for `ChangeConnectionPriorityInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List changeConnectionPriorityInfoDescriptor = $convert.base64Decode('ChxDaGFuZ2VDb25uZWN0aW9uUHJpb3JpdHlJbmZvEhoKCGRldmljZUlkGAEgASgJUghkZXZpY2VJZBIpCgdmYWlsdXJlGAIgASgLMg8uR2VuZXJpY0ZhaWx1cmVSB2ZhaWx1cmU=');
+@$core.Deprecated('Use characteristicAddressDescriptor instead')
+const CharacteristicAddress$json = const {
+  '1': 'CharacteristicAddress',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'serviceUuid', '3': 2, '4': 1, '5': 11, '6': '.Uuid', '10': 'serviceUuid'},
+    const {'1': 'characteristicUuid', '3': 3, '4': 1, '5': 11, '6': '.Uuid', '10': 'characteristicUuid'},
+  ],
+};
+
+/// Descriptor for `CharacteristicAddress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List characteristicAddressDescriptor = $convert.base64Decode('ChVDaGFyYWN0ZXJpc3RpY0FkZHJlc3MSGgoIZGV2aWNlSWQYASABKAlSCGRldmljZUlkEicKC3NlcnZpY2VVdWlkGAIgASgLMgUuVXVpZFILc2VydmljZVV1aWQSNQoSY2hhcmFjdGVyaXN0aWNVdWlkGAMgASgLMgUuVXVpZFISY2hhcmFjdGVyaXN0aWNVdWlk');
+@$core.Deprecated('Use serviceDataEntryDescriptor instead')
+const ServiceDataEntry$json = const {
+  '1': 'ServiceDataEntry',
+  '2': const [
+    const {'1': 'serviceUuid', '3': 1, '4': 1, '5': 11, '6': '.Uuid', '10': 'serviceUuid'},
+    const {'1': 'data', '3': 2, '4': 1, '5': 12, '10': 'data'},
+  ],
+};
+
+/// Descriptor for `ServiceDataEntry`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List serviceDataEntryDescriptor = $convert.base64Decode('ChBTZXJ2aWNlRGF0YUVudHJ5EicKC3NlcnZpY2VVdWlkGAEgASgLMgUuVXVpZFILc2VydmljZVV1aWQSEgoEZGF0YRgCIAEoDFIEZGF0YQ==');
+@$core.Deprecated('Use servicesWithCharacteristicsDescriptor instead')
+const ServicesWithCharacteristics$json = const {
+  '1': 'ServicesWithCharacteristics',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.ServiceWithCharacteristics', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `ServicesWithCharacteristics`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List servicesWithCharacteristicsDescriptor = $convert.base64Decode('ChtTZXJ2aWNlc1dpdGhDaGFyYWN0ZXJpc3RpY3MSMQoFaXRlbXMYASADKAsyGy5TZXJ2aWNlV2l0aENoYXJhY3RlcmlzdGljc1IFaXRlbXM=');
+@$core.Deprecated('Use serviceWithCharacteristicsDescriptor instead')
+const ServiceWithCharacteristics$json = const {
+  '1': 'ServiceWithCharacteristics',
+  '2': const [
+    const {'1': 'serviceId', '3': 1, '4': 1, '5': 11, '6': '.Uuid', '10': 'serviceId'},
+    const {'1': 'characteristics', '3': 2, '4': 3, '5': 11, '6': '.Uuid', '10': 'characteristics'},
+  ],
+};
+
+/// Descriptor for `ServiceWithCharacteristics`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List serviceWithCharacteristicsDescriptor = $convert.base64Decode('ChpTZXJ2aWNlV2l0aENoYXJhY3RlcmlzdGljcxIjCglzZXJ2aWNlSWQYASABKAsyBS5VdWlkUglzZXJ2aWNlSWQSLwoPY2hhcmFjdGVyaXN0aWNzGAIgAygLMgUuVXVpZFIPY2hhcmFjdGVyaXN0aWNz');
+@$core.Deprecated('Use discoverServicesRequestDescriptor instead')
+const DiscoverServicesRequest$json = const {
+  '1': 'DiscoverServicesRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+  ],
+};
+
+/// Descriptor for `DiscoverServicesRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List discoverServicesRequestDescriptor = $convert.base64Decode('ChdEaXNjb3ZlclNlcnZpY2VzUmVxdWVzdBIaCghkZXZpY2VJZBgBIAEoCVIIZGV2aWNlSWQ=');
+@$core.Deprecated('Use discoverServicesInfoDescriptor instead')
+const DiscoverServicesInfo$json = const {
+  '1': 'DiscoverServicesInfo',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+    const {'1': 'services', '3': 2, '4': 3, '5': 11, '6': '.DiscoveredService', '10': 'services'},
+  ],
+};
+
+/// Descriptor for `DiscoverServicesInfo`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List discoverServicesInfoDescriptor = $convert.base64Decode('ChREaXNjb3ZlclNlcnZpY2VzSW5mbxIaCghkZXZpY2VJZBgBIAEoCVIIZGV2aWNlSWQSLgoIc2VydmljZXMYAiADKAsyEi5EaXNjb3ZlcmVkU2VydmljZVIIc2VydmljZXM=');
+@$core.Deprecated('Use discoveredServiceDescriptor instead')
+const DiscoveredService$json = const {
+  '1': 'DiscoveredService',
+  '2': const [
+    const {'1': 'serviceUuid', '3': 1, '4': 1, '5': 11, '6': '.Uuid', '10': 'serviceUuid'},
+    const {'1': 'characteristicUuids', '3': 2, '4': 3, '5': 11, '6': '.Uuid', '10': 'characteristicUuids'},
+    const {'1': 'includedServices', '3': 3, '4': 3, '5': 11, '6': '.DiscoveredService', '10': 'includedServices'},
+    const {'1': 'characteristics', '3': 4, '4': 3, '5': 11, '6': '.DiscoveredCharacteristic', '10': 'characteristics'},
+  ],
+};
+
+/// Descriptor for `DiscoveredService`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List discoveredServiceDescriptor = $convert.base64Decode('ChFEaXNjb3ZlcmVkU2VydmljZRInCgtzZXJ2aWNlVXVpZBgBIAEoCzIFLlV1aWRSC3NlcnZpY2VVdWlkEjcKE2NoYXJhY3RlcmlzdGljVXVpZHMYAiADKAsyBS5VdWlkUhNjaGFyYWN0ZXJpc3RpY1V1aWRzEj4KEGluY2x1ZGVkU2VydmljZXMYAyADKAsyEi5EaXNjb3ZlcmVkU2VydmljZVIQaW5jbHVkZWRTZXJ2aWNlcxJDCg9jaGFyYWN0ZXJpc3RpY3MYBCADKAsyGS5EaXNjb3ZlcmVkQ2hhcmFjdGVyaXN0aWNSD2NoYXJhY3RlcmlzdGljcw==');
+@$core.Deprecated('Use discoveredCharacteristicDescriptor instead')
+const DiscoveredCharacteristic$json = const {
+  '1': 'DiscoveredCharacteristic',
+  '2': const [
+    const {'1': 'characteristicId', '3': 1, '4': 1, '5': 11, '6': '.Uuid', '10': 'characteristicId'},
+    const {'1': 'serviceId', '3': 2, '4': 1, '5': 11, '6': '.Uuid', '10': 'serviceId'},
+    const {'1': 'isReadable', '3': 3, '4': 1, '5': 8, '10': 'isReadable'},
+    const {'1': 'isWritableWithResponse', '3': 4, '4': 1, '5': 8, '10': 'isWritableWithResponse'},
+    const {'1': 'isWritableWithoutResponse', '3': 5, '4': 1, '5': 8, '10': 'isWritableWithoutResponse'},
+    const {'1': 'isNotifiable', '3': 6, '4': 1, '5': 8, '10': 'isNotifiable'},
+    const {'1': 'isIndicatable', '3': 7, '4': 1, '5': 8, '10': 'isIndicatable'},
+  ],
+};
+
+/// Descriptor for `DiscoveredCharacteristic`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List discoveredCharacteristicDescriptor = $convert.base64Decode('ChhEaXNjb3ZlcmVkQ2hhcmFjdGVyaXN0aWMSMQoQY2hhcmFjdGVyaXN0aWNJZBgBIAEoCzIFLlV1aWRSEGNoYXJhY3RlcmlzdGljSWQSIwoJc2VydmljZUlkGAIgASgLMgUuVXVpZFIJc2VydmljZUlkEh4KCmlzUmVhZGFibGUYAyABKAhSCmlzUmVhZGFibGUSNgoWaXNXcml0YWJsZVdpdGhSZXNwb25zZRgEIAEoCFIWaXNXcml0YWJsZVdpdGhSZXNwb25zZRI8Chlpc1dyaXRhYmxlV2l0aG91dFJlc3BvbnNlGAUgASgIUhlpc1dyaXRhYmxlV2l0aG91dFJlc3BvbnNlEiIKDGlzTm90aWZpYWJsZRgGIAEoCFIMaXNOb3RpZmlhYmxlEiQKDWlzSW5kaWNhdGFibGUYByABKAhSDWlzSW5kaWNhdGFibGU=');
+@$core.Deprecated('Use readRssiRequestDescriptor instead')
+const ReadRssiRequest$json = const {
+  '1': 'ReadRssiRequest',
+  '2': const [
+    const {'1': 'deviceId', '3': 1, '4': 1, '5': 9, '10': 'deviceId'},
+  ],
+};
+
+/// Descriptor for `ReadRssiRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List readRssiRequestDescriptor = $convert.base64Decode('Cg9SZWFkUnNzaVJlcXVlc3QSGgoIZGV2aWNlSWQYASABKAlSCGRldmljZUlk');
+@$core.Deprecated('Use readRssiResultDescriptor instead')
+const ReadRssiResult$json = const {
+  '1': 'ReadRssiResult',
+  '2': const [
+    const {'1': 'rssi', '3': 1, '4': 1, '5': 5, '10': 'rssi'},
+  ],
+};
+
+/// Descriptor for `ReadRssiResult`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List readRssiResultDescriptor = $convert.base64Decode('Cg5SZWFkUnNzaVJlc3VsdBISCgRyc3NpGAEgASgFUgRyc3Np');
+@$core.Deprecated('Use uuidDescriptor instead')
+const Uuid$json = const {
+  '1': 'Uuid',
+  '2': const [
+    const {'1': 'data', '3': 1, '4': 1, '5': 12, '10': 'data'},
+  ],
+};
+
+/// Descriptor for `Uuid`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List uuidDescriptor = $convert.base64Decode('CgRVdWlkEhIKBGRhdGEYASABKAxSBGRhdGE=');
+@$core.Deprecated('Use genericFailureDescriptor instead')
+const GenericFailure$json = const {
+  '1': 'GenericFailure',
+  '2': const [
+    const {'1': 'code', '3': 1, '4': 1, '5': 5, '10': 'code'},
+    const {'1': 'message', '3': 2, '4': 1, '5': 9, '10': 'message'},
+  ],
+};
+
+/// Descriptor for `GenericFailure`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List genericFailureDescriptor = $convert.base64Decode('Cg5HZW5lcmljRmFpbHVyZRISCgRjb2RlGAEgASgFUgRjb2RlEhgKB21lc3NhZ2UYAiABKAlSB21lc3NhZ2U=');

--- a/packages/reactive_ble_mobile/lib/src/generated/bledata.pbserver.dart
+++ b/packages/reactive_ble_mobile/lib/src/generated/bledata.pbserver.dart
@@ -1,0 +1,9 @@
+///
+//  Generated code. Do not modify.
+//  source: bledata.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+export 'bledata.pb.dart';
+

--- a/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
+++ b/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
@@ -219,14 +219,18 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
           .then((data) => _protobufConverter.clearGattCacheResultFrom(data!));
 
   @override
-  Future<int> readRssi(String deviceId) async => _bleMethodChannel
-      .invokeMethod<List<int>>(
-        "readRssi",
-        _argsToProtobufConverter
-            .createReadRssiRequest(deviceId)
-            .writeToBuffer(),
-      )
-      .then((data) => _protobufConverter.readRssiResultFrom(data!));
+  Stream<int> streamRssi(String deviceId, Duration rssiPeriod) =>
+      Stream.periodic(
+        rssiPeriod,
+        (computationCount) => _bleMethodChannel
+            .invokeMethod<List<int>>(
+              "readRssi",
+              _argsToProtobufConverter
+                  .createReadRssiRequest(deviceId)
+                  .writeToBuffer(),
+            )
+            .then((data) => _protobufConverter.readRssiResultFrom(data!)),
+      ).asyncMap<int>((event) async => event);
 
   @override
   Future<List<DiscoveredService>> discoverServices(String deviceId) async =>

--- a/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
+++ b/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
@@ -219,6 +219,16 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
           .then((data) => _protobufConverter.clearGattCacheResultFrom(data!));
 
   @override
+  Future<int> readRssi(String deviceId) async => _bleMethodChannel
+      .invokeMethod<List<int>>(
+        "readRssi",
+        _argsToProtobufConverter
+            .createReadRssiRequest(deviceId)
+            .writeToBuffer(),
+      )
+      .then((data) => _protobufConverter.readRssiResultFrom(data!));
+
+  @override
   Future<List<DiscoveredService>> discoverServices(String deviceId) async =>
       _bleMethodChannel
           .invokeMethod<List<int>>(

--- a/packages/reactive_ble_mobile/protos/bledata.proto
+++ b/packages/reactive_ble_mobile/protos/bledata.proto
@@ -141,6 +141,14 @@ message DiscoveredCharacteristic {
     bool isIndicatable = 7;
 }
 
+message ReadRssiRequest {
+    string deviceId = 1;
+}
+
+message ReadRssiResult {
+    int32 rssi = 1;
+}
+
 message Uuid {
     bytes data = 1;
 }

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -11,8 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   protobuf: ^2.0.0
-  reactive_ble_platform_interface: 
-    path: ../reactive_ble_platform_interface
+  reactive_ble_platform_interface: ^5.0.2
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_test:

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
   protobuf: ^2.0.0
-  reactive_ble_platform_interface: ^5.0.2
+  reactive_ble_platform_interface: 
+    path: ../reactive_ble_platform_interface
 dev_dependencies:
   build_runner: ^2.1.2
   flutter_test:

--- a/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
@@ -87,7 +87,7 @@ abstract class ReactiveBlePlatform extends PlatformInterface {
     throw UnimplementedError('clearGattCache() has not been implemented.');
   }
 
-  Future<int> readRssi(String deviceId) async {
+  Stream<int> streamRssi(String deviceId, Duration rssiPeriod) {
     throw UnimplementedError(
         'readRssi(String deviceId) has not been implemented.');
   }

--- a/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
@@ -87,6 +87,11 @@ abstract class ReactiveBlePlatform extends PlatformInterface {
     throw UnimplementedError('clearGattCache() has not been implemented.');
   }
 
+  Future<int> readRssi(String deviceId) async {
+    throw UnimplementedError(
+        'readRssi(String deviceId) has not been implemented.');
+  }
+
   /// Connects to a specific device and the connection remains `established` until
   /// the stream is `cancelled` or the connection is closed by the peripheral.
   ///


### PR DESCRIPTION
resolves #292 
Adds the ability to read the RSSI of a connected device. While the issue did ask for an RSSI stream I decided to go with just a Future instead. The reason being is the native BLE layers (to the best of my knowledge) don't have a mechanism for streaming RSSI, just reading the value once per call, as such I thought that it would be best to maintain that in the Flutter-side API.

I also updated the example app to include a Read RSSI button, mostly just as a proof of functionality, so it can be removed if need-be, you can see that demonstrated below:
### Android
<img src="https://user-images.githubusercontent.com/16006381/182738323-4859a335-20c6-47fb-9247-509483264018.gif" width="50%" height="50%"/>


### iOS
<img src="https://user-images.githubusercontent.com/16006381/182738444-a3ce60af-6a21-4f67-97ba-6129e4578452.gif" width="50%" height="50%"/>


