### PR TITLE
Federated implementations

### DIFF
--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_reactive_ble/src/connected_device_operation.dart';
 import 'package:flutter_reactive_ble/src/debug_logger.dart';
 import 'package:flutter_reactive_ble/src/device_connector.dart';
@@ -116,7 +117,7 @@ class FlutterReactiveBle {
       );
       _deviceScanner = DeviceScannerImpl(
         blePlatform: _blePlatform,
-        platformIsAndroid: () => Platform.isAndroid,
+        platformIsAndroid: () => !kIsWeb && Platform.isAndroid,
         delayAfterScanCompletion: Future<void>.delayed(
           const Duration(milliseconds: 300),
         ),

--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -104,7 +104,7 @@ class FlutterReactiveBle {
         print,
       );
 
-      ReactiveBlePlatform.instance =
+      ReactiveBlePlatform.instance ??=
           const ReactiveBleMobilePlatformFactory().create();
 
       _blePlatform = ReactiveBlePlatform.instance;


### PR DESCRIPTION
Following the discussion in #544, i'm trying to publish a web implementation of this plugin but i'm facing a couple of issues:

- ReactiveBlePlatform class exposes the set instance method to enable other platform-specific implementations but the instance is currently always re-set using ReactiveBleMobilePlatformFactory https://github.com/PhilipsHue/flutter_reactive_ble/blob/master/packages/flutter_reactive_ble/lib/src/reactive_ble.dart#L107

- platformIsAndroid variable is currently set using Platform.isAndroid, which rises an exeception in non-native environments