### PR TITLE
Make operator == override parameters non-nullable

### DIFF
--- a/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
@@ -40,6 +40,6 @@ class DiscoveredCharacteristic {
   @override
   bool operator ==(Object other) =>
       runtimeType == other.runtimeType &&
-      characteristicId == other.characteristicId &&
-      serviceId == other.serviceId;
+      characteristicId == (other as DiscoveredCharacteristic).characteristicId &&
+      serviceId == (other as DiscoveredCharacteristic).serviceId;
 }

--- a/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
@@ -39,7 +39,8 @@ class DiscoveredCharacteristic {
 
   @override
   bool operator ==(Object other) =>
+      other is DiscoveredCharacteristic &&
       runtimeType == other.runtimeType &&
-      characteristicId == (other as DiscoveredCharacteristic).characteristicId &&
-      serviceId == (other as DiscoveredCharacteristic).serviceId;
+      characteristicId == other.characteristicId &&
+      serviceId == other.serviceId;
 }

--- a/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/discovered_characteristic.dart
@@ -38,7 +38,7 @@ class DiscoveredCharacteristic {
       (((17 * 37) + characteristicId.hashCode) * 37 + serviceId.hashCode) * 37;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       runtimeType == other.runtimeType &&
       characteristicId == other.characteristicId &&
       serviceId == other.serviceId;

--- a/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
@@ -31,7 +31,7 @@ class QualifiedCharacteristic {
       deviceId.hashCode;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       runtimeType == other.runtimeType &&
       characteristicId == other.characteristicId &&
       serviceId == other.serviceId &&

--- a/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
@@ -32,8 +32,9 @@ class QualifiedCharacteristic {
 
   @override
   bool operator ==(Object other) =>
+      other is QualifiedCharacteristic &&
       runtimeType == other.runtimeType &&
-      characteristicId == (other as QualifiedCharacteristic).characteristicId &&
-      serviceId == (other as QualifiedCharacteristic).serviceId &&
-      deviceId == (other as QualifiedCharacteristic).deviceId;
+      characteristicId == other.characteristicId &&
+      serviceId == other.serviceId &&
+      deviceId == other.deviceId;
 }

--- a/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/qualified_characteristic.dart
@@ -33,7 +33,7 @@ class QualifiedCharacteristic {
   @override
   bool operator ==(Object other) =>
       runtimeType == other.runtimeType &&
-      characteristicId == other.characteristicId &&
-      serviceId == other.serviceId &&
-      deviceId == other.deviceId;
+      characteristicId == (other as QualifiedCharacteristic).characteristicId &&
+      serviceId == (other as QualifiedCharacteristic).serviceId &&
+      deviceId == (other as QualifiedCharacteristic).deviceId;
 }

--- a/packages/reactive_ble_platform_interface/lib/src/model/unit.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/unit.dart
@@ -5,7 +5,7 @@ class Unit {
   const Unit();
 
   @override
-  bool operator ==(dynamic other) => other.runtimeType == runtimeType;
+  bool operator ==(Object other) => other.runtimeType == runtimeType;
 
   @override
   int get hashCode => 1;

--- a/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
@@ -68,9 +68,11 @@ class Uuid {
       data.fold(17, (hash, octet) => 37 * hash + octet.hashCode);
 
   @override
-  bool operator ==(Object other) =>
-      other.runtimeType == runtimeType &&
-      const DeepCollectionEquality().equals((other as Uuid).data, data);
+  bool operator ==(Object other) {
+    return other is Uuid &&
+        other.runtimeType == runtimeType &&
+        const DeepCollectionEquality().equals(other.data, data);
+  }
 }
 
 @immutable

--- a/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
@@ -70,7 +70,7 @@ class Uuid {
   @override
   bool operator ==(Object other) =>
       other.runtimeType == runtimeType &&
-      const DeepCollectionEquality().equals(other.data, data);
+      const DeepCollectionEquality().equals((other as Uuid).data, data);
 }
 
 @immutable

--- a/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
@@ -68,7 +68,7 @@ class Uuid {
       data.fold(17, (hash, octet) => 37 * hash + octet.hashCode);
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other.runtimeType == runtimeType &&
       const DeepCollectionEquality().equals(other.data, data);
 }

--- a/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/model/uuid.dart
@@ -68,11 +68,10 @@ class Uuid {
       data.fold(17, (hash, octet) => 37 * hash + octet.hashCode);
 
   @override
-  bool operator ==(Object other) {
-    return other is Uuid &&
-        other.runtimeType == runtimeType &&
-        const DeepCollectionEquality().equals(other.data, data);
-  }
+  bool operator ==(Object other) =>
+      other is Uuid &&
+      other.runtimeType == runtimeType &&
+      const DeepCollectionEquality().equals(other.data, data);
 }
 
 @immutable


### PR DESCRIPTION
Make operator == override parameters non-nullable. See dart-lang/linter#3441

Work towards dart-lang/sdk#51038.