### PR TITLE
Enable quick-setup by default

### DIFF
--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -21,7 +21,11 @@ dependencies:
     sdk: flutter
   functional_data: ^1.0.0
   meta: ^1.3.0
-  reactive_ble_mobile: ^5.0.3
+  reactive_ble_mobile: 
+    git:
+      url: https://github.com/Klievan/flutter_reactive_ble
+      ref: master
+      path: packages/reactive_ble_mobile
   reactive_ble_platform_interface: ^5.0.3
 dev_dependencies:
   build_runner: ^2.1.2

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -290,7 +290,7 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
                             val mode = if (char.descriptors.isEmpty()) {
                                 NotificationSetupMode.COMPAT
                             } else {
-                                NotificationSetupMode.DEFAULT
+                                NotificationSetupMode.QUICK_SETUP
                             }
 
                             if ((char.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0) {


### PR DESCRIPTION
Fixes https://github.com/PhilipsHue/flutter_reactive_ble/issues/211

Setting the NotificationSetupMode to QUICK_SETUP makes it so the notification-observable stream gets opened BEFORE writing the descriptor on the peripheral. This makes it so that if the peripheral starts sending notifications instantly upon subscribing, no data is lost. Otherwise, the couple of milliseconds between writing the notification-descriptor and propagating the observable stream to the Flutter app, notifications can be received by the phone that are missed by the app.

Other BLE-libraries seem to be also using AndroidRxBle but did not have this issue, so I can only assume they were using the same mode. 