### PR TITLE
Remove dead code from reactive_ble_platform_test

### DIFF
--- a/packages/reactive_ble_mobile/test/reactive_ble_platform_test.dart
+++ b/packages/reactive_ble_mobile/test/reactive_ble_platform_test.dart
@@ -63,7 +63,6 @@ void main() {
 
     group('connect to device', () {
       late pb.ConnectToDeviceRequest request;
-      StreamSubscription? subscription;
       setUp(() {
         request = pb.ConnectToDeviceRequest();
         when(_argsConverter.createConnectToDeviceArgs('id', any, any))
@@ -84,10 +83,6 @@ void main() {
       test('It emits 1 item', () async {
         final length = await _sut.connectToDevice('id', {}, null).length;
         expect(length, 1);
-      });
-
-      tearDown(() async {
-        await subscription?.cancel();
       });
     });
 


### PR DESCRIPTION
`DEAD_CODE` will soon be a warning which will start to fail `dart analyze` (without `--fatal-warnings=false`).

This change will prevent that warning from being reported.