### PR TITLE
Will not popup a dialog while the bluetooth is not power on on iOS.Add support for multiple manufacturerData on Android.

### DIFF
--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ManufacturerDataConverter.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/converters/ManufacturerDataConverter.kt
@@ -6,12 +6,17 @@ fun extractManufacturerData(manufacturerData: SparseArray<ByteArray>?): ByteArra
     val rawData = mutableListOf<Byte>()
 
     if (manufacturerData != null && manufacturerData.size() > 0) {
-        val companyId = manufacturerData.keyAt(0)
-        val payload = manufacturerData.get(companyId)
-
-        rawData.add((companyId.toByte()))
-        rawData.add(((companyId.shr(Byte.SIZE_BITS)).toByte()))
-        rawData.addAll(2, payload.asList())
+        var index = 0;
+        for(i in 0 until manufacturerData.size()){
+            val companyId = manufacturerData.keyAt(i)
+            val payload = manufacturerData.get(companyId)
+            rawData.add((companyId.toByte()))
+            rawData.add(((companyId.shr(Byte.SIZE_BITS)).toByte()))
+            index += 2;
+            var list = payload.asList();
+            rawData.addAll(index, list)
+            index += list.size;
+        }
     }
 
     return rawData.toByteArray()

--- a/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Central.swift
+++ b/packages/reactive_ble_mobile/ios/Classes/ReactiveBle/Central.swift
@@ -99,7 +99,8 @@ final class Central {
         )
         self.centralManager = CBCentralManager(
             delegate: centralManagerDelegate,
-            queue: nil
+            queue: nil,
+            options: [CBCentralManagerOptionShowPowerAlertKey:false]
         )
     }
 


### PR DESCRIPTION
Fix #216: To keep consistent with the experience on the iOS. Add support for multiple manufacturerData on Android.
Fix #689: To keep consistent with the experience on the Android. Will not popup a dialog while the bluetooth is not power on on iOS.