### PR TITLE
Remove asyncness from flutter_reactive_ble_exampel:ble_device_connector.dart:connect

### DIFF
--- a/example/lib/src/ble/ble_device_connector.dart
+++ b/example/lib/src/ble/ble_device_connector.dart
@@ -21,7 +21,7 @@ class BleDeviceConnector extends ReactiveState<ConnectionStateUpdate> {
   // ignore: cancel_subscriptions
   late StreamSubscription<ConnectionStateUpdate> _connection;
 
-  Future<void> connect(String deviceId) async {
+  void connect(String deviceId) {
     _logMessage('Start connecting to $deviceId');
     _connection = _ble.connectToDevice(id: deviceId).listen(
       (update) {


### PR DESCRIPTION
This doesn't need to be an async future because it never awaits. Therefore, for clarity, remove its asyncness.