### PR TITLE
Make Plugin Controller not static so it creates new instance for each Flutter Engine

### DIFF
--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ReactiveBlePlugin.kt
@@ -1,40 +1,22 @@
 package com.signify.hue.flutterreactiveble
 
-import android.content.Context
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.Result
 
 class ReactiveBlePlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
+    private val pluginController = PluginController()
+
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        initializePlugin(binding.binaryMessenger, binding.applicationContext, this)
+        val channel = MethodChannel(binding.binaryMessenger, "flutter_reactive_ble_method")
+        channel.setMethodCallHandler(this)
+
+        pluginController.initialize(binding.binaryMessenger, binding.applicationContext)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        deinitializePlugin()
-    }
-
-    companion object {
-        lateinit var pluginController: PluginController
-
-        @JvmStatic
-        private fun initializePlugin(
-            messenger: BinaryMessenger,
-            context: Context,
-            plugin: ReactiveBlePlugin
-        ) {
-            val channel = MethodChannel(messenger, "flutter_reactive_ble_method")
-            channel.setMethodCallHandler(plugin)
-            pluginController = PluginController()
-            pluginController.initialize(messenger, context)
-        }
-
-        @JvmStatic
-        private fun deinitializePlugin() {
-            pluginController.deinitialize()
-        }
+        pluginController.deinitialize()
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {


### PR DESCRIPTION
I encountered a bug with this package when using together with flutter_foreground_task plugin.

flutter_foreground_task plugin creates a separate Flutter Engine in android foreground task to perform some work. This engine also initializes flutter_reactive_ble plugin.

However, because the PluginController instance is static, it would deinitialize the plugin when Flutter Engine that the app uses is destroyed (on app force close) which leaves the plugin deinitialized for the potentionally running Flutter Engine in the foreground task.

This PR ensures that each Flutter Engine has its own instance of the PluginController which deintializes only if the given engine is destroyed. This allows for plugin usage within background contexts like the foreground task on android.