### PR TITLE
Migrate away from deprecated strong-mode analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,10 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    # strict-casts: true -- DISABLED: Enabled in Dart 2.17
+    strict-inference: true
+    strict-raw-types: true
   exclude:
     - "bin/cache/**"
     - "**/*.freezed.dart"

--- a/example/lib/src/ble/ble_device_connector.dart
+++ b/example/lib/src/ble/ble_device_connector.dart
@@ -6,7 +6,7 @@ import 'package:flutter_reactive_ble_example/src/ble/reactive_state.dart';
 class BleDeviceConnector extends ReactiveState<ConnectionStateUpdate> {
   BleDeviceConnector({
     required FlutterReactiveBle ble,
-    required Function(String message) logMessage,
+    required void Function(String message) logMessage,
   })  : _ble = ble,
         _logMessage = logMessage;
 

--- a/example/lib/src/ble/ble_scanner.dart
+++ b/example/lib/src/ble/ble_scanner.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 class BleScanner implements ReactiveState<BleScannerState> {
   BleScanner({
     required FlutterReactiveBle ble,
-    required Function(String message) logMessage,
+    required void Function(String message) logMessage,
   })  : _ble = ble,
         _logMessage = logMessage;
 
@@ -59,7 +59,7 @@ class BleScanner implements ReactiveState<BleScannerState> {
     await _stateStreamController.close();
   }
 
-  StreamSubscription? _subscription;
+  StreamSubscription<DiscoveredDevice>? _subscription;
 }
 
 @immutable

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -207,7 +207,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_lints:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: flutter_lints
       sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
@@ -217,9 +217,10 @@ packages:
   flutter_reactive_ble:
     dependency: "direct main"
     description:
-      path: "../packages/flutter_reactive_ble"
-      relative: false
-    source: path
+      name: flutter_reactive_ble
+      sha256: dfcd3cca271a054121ef96fde0fdad43274a5a38b423fc3f519fd9edc43e42c9
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.1"
   flutter_test:
     dependency: "direct dev"
@@ -435,18 +436,20 @@ packages:
     source: hosted
     version: "1.2.3"
   reactive_ble_mobile:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../packages/reactive_ble_mobile"
-      relative: false
-    source: path
+      name: reactive_ble_mobile
+      sha256: "2fdd8bcd00533f3e1e544030edeba723ce2dfdd24c3b22a04103b410b1272290"
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.1"
   reactive_ble_platform_interface:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../packages/reactive_ble_platform_interface"
-      relative: true
-    source: path
+      name: reactive_ble_platform_interface
+      sha256: d0c0041de584df5c697d276ae8c3ddc767b2c364ed29b4ae25126c57e4467cba
+      url: "https://pub.dev"
+    source: hosted
     version: "5.1.1"
   shelf:
     dependency: transitive
@@ -583,4 +586,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.0.0 <4.0.0"
-  flutter: ">=1.16.0"
+  flutter: ">=2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,12 +5,11 @@ publish_to: 'none'
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
-  flutter: ">=1.10.0"
+  flutter: ">=2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_lints: ^1.0.4
   flutter_reactive_ble: ^5.1.1
   functional_data: ^1.0.0
   intl: ^0.17.0
@@ -20,6 +19,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.3.3
   dependency_validator: ^3.1.0
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
   functional_data_generator: ^1.1.2

--- a/packages/flutter_reactive_ble/lib/src/rx_ext/serial_disposable.dart
+++ b/packages/flutter_reactive_ble/lib/src/rx_ext/serial_disposable.dart
@@ -41,10 +41,10 @@ class _SerialAlreadyDisposed extends Error {
 }
 
 /// A [SerialDisposable] that contains an underlying stream subscription.
-class StreamSubscriptionSerialDisposable
-    extends SerialDisposable<StreamSubscription> {
+class StreamSubscriptionSerialDisposable<T>
+    extends SerialDisposable<StreamSubscription<T>> {
   StreamSubscriptionSerialDisposable()
-      : super((StreamSubscription subscription) async {
+      : super((StreamSubscription<T> subscription) async {
           await subscription.cancel();
           return const Unit();
         });

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   reactive_ble_platform_interface: ^5.1.1
 dev_dependencies:
   build_runner: ^2.3.3
+  flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
   mockito: ^5.0.14


### PR DESCRIPTION
The old strong-mode options have been deprecated for a while and are set [for removal](https://github.com/dart-lang/sdk/issues/50679). They have been replaced and augmented by newer [analysis language modes](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks).