### PR TITLE
Fix typo in log message disconnect in example

### DIFF
--- a/example/lib/src/ble/ble_device_connector.dart
+++ b/example/lib/src/ble/ble_device_connector.dart
@@ -36,7 +36,7 @@ class BleDeviceConnector extends ReactiveState<ConnectionStateUpdate> {
 
   Future<void> disconnect(String deviceId) async {
     try {
-      _logMessage('disconnecting to device: $deviceId');
+      _logMessage('disconnecting from device: $deviceId');
       await _connection.cancel();
     } on Exception catch (e, _) {
       _logMessage("Error disconnecting from a device: $e");


### PR DESCRIPTION
Fixed typo in log message disconnect in example: changed "disconnecting to device:" into the more proper "disconnecting from device:" (similar to log message in exception part).