### PR TITLE
Use proper platform_interface dependency version

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_reactive_ble: ^5.2.0
+  flutter_reactive_ble: ^5.3.0
   functional_data: ^1.0.0
   intl: ^0.17.0
 

--- a/packages/flutter_reactive_ble/pubspec.yaml
+++ b/packages/flutter_reactive_ble/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
     sdk: flutter
   functional_data: ^1.0.0
   meta: ^1.3.0
-  reactive_ble_mobile: ^5.2.0
-  reactive_ble_platform_interface: ^5.2.0
+  reactive_ble_mobile: ^5.3.0
+  reactive_ble_platform_interface: ^5.3.0
 
 dependency_overrides:
   reactive_ble_mobile:

--- a/packages/reactive_ble_mobile/pubspec.yaml
+++ b/packages/reactive_ble_mobile/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   protobuf: ^2.0.0
-  reactive_ble_platform_interface: ^5.2.0
+  reactive_ble_platform_interface: ^5.3.0
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
Update required version of the plugin to fix 5.3.0 release.

Fixes https://github.com/PhilipsHue/flutter_reactive_ble/issues/835

This is annoying issue and we had it quite often in Plus Plugins earlier before.