### PR TITLE
Add methods to disable logger completely (#708)

### DIFF
--- a/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
+++ b/packages/flutter_reactive_ble/lib/src/reactive_ble.dart
@@ -25,9 +25,9 @@ class FlutterReactiveBle {
     required DeviceScanner deviceScanner,
     required DeviceConnector deviceConnector,
     required ConnectedDeviceOperation connectedDeviceOperation,
-    required Logger debugLogger,
     required Future<void> initialization,
     required ReactiveBlePlatform reactiveBlePlatform,
+    Logger? debugLogger,
   }) {
     _deviceScanner = deviceScanner;
     _deviceConnector = deviceConnector;
@@ -90,7 +90,7 @@ class FlutterReactiveBle {
   late DeviceConnector _deviceConnector;
   late ConnectedDeviceOperation _connectedDeviceOperator;
   late DeviceScanner _deviceScanner;
-  late Logger _debugLogger;
+  Logger? _debugLogger;
 
   /// Initializes this [FlutterReactiveBle] instance and its platform-specific
   /// counterparts.
@@ -433,9 +433,19 @@ class FlutterReactiveBle {
   ///
   /// Use [LogLevel.verbose] for full debug output. Make sure to  run this only for debugging purposes.
   /// Use [LogLevel.none] to disable logging. This is also the default.
-  set logLevel(LogLevel logLevel) => _debugLogger.logLevel = logLevel;
+  set logLevel(LogLevel logLevel) => _debugLogger?.logLevel = logLevel;
 
-  LogLevel get logLevel => _debugLogger.logLevel;
+  LogLevel get logLevel => _debugLogger?.logLevel ?? LogLevel.none;
+
+  /// Sets the logger.
+  ///
+  /// Set to null to disable logging.
+  set logger(Logger? logger) {
+    _debugLogger = logger;
+    _blePlatform.logger = logger;
+  }
+
+  Logger? get logger => _debugLogger;
 }
 
 /// An instance of this object should not be used after its device has lost its connection.

--- a/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
+++ b/packages/reactive_ble_mobile/lib/src/reactive_ble_mobile_platform.dart
@@ -20,8 +20,9 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
         _connectedDeviceRawStream = connectedDeviceChannel,
         _charUpdateRawStream = charUpdateChannel,
         _bleStatusRawChannel = bleStatusChannel,
-        _bleDeviceScanRawStream = bleDeviceScanChannel,
-        _logger = logger;
+        _bleDeviceScanRawStream = bleDeviceScanChannel{
+          super.logger = logger;
+        }
 
   final ArgsToProtobufConverter _argsToProtobufConverter;
   final ProtobufConverter _protobufConverter;
@@ -30,7 +31,6 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   final Stream<List<int>> _charUpdateRawStream;
   final Stream<List<int>> _bleDeviceScanRawStream;
   final Stream<List<int>> _bleStatusRawChannel;
-  final Logger? _logger;
 
   Stream<ConnectionStateUpdate>? _connectionUpdateStream;
   Stream<CharacteristicValue>? _charValueStream;
@@ -43,7 +43,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
           .map(_protobufConverter.connectionStateUpdateFrom)
           .map(
         (update) {
-          _logger?.log(
+          logger?.log(
             'Received $ConnectionStateUpdate(deviceId: ${update.deviceId}, connectionState: ${update.connectionState}, failure: ${update.failure})',
           );
           return update;
@@ -56,7 +56,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
           .map(_protobufConverter.characteristicValueFrom)
           .map(
         (update) {
-          _logger?.log(
+          logger?.log(
             'Received $CharacteristicValue(characteristic: ${update.characteristic}, result: ${update.runtimeType})',
           );
           return update;
@@ -67,7 +67,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   Stream<ScanResult> get scanStream => _scanResultStream ??=
           _bleDeviceScanRawStream.map(_protobufConverter.scanResultFrom).map(
         (scanResult) {
-          _logger?.log(
+          logger?.log(
             'Received $ScanResult(result: ${scanResult.result})',
           );
           return scanResult;
@@ -79,19 +79,19 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
       _bleStatusStream ??= _bleStatusRawChannel
           .map(_protobufConverter.bleStatusFrom)
           .map((status) {
-        _logger?.log('Received $BleStatus update: $status');
+        logger?.log('Received $BleStatus update: $status');
         return status;
       });
 
   @override
   Future<void> initialize() {
-    _logger?.log('Initialize BLE platform');
+    logger?.log('Initialize BLE platform');
     return _bleMethodChannel.invokeMethod("initialize");
   }
 
   @override
   Future<void> deinitialize() {
-    _logger?.log('Deinitialize BLE platform');
+    logger?.log('Deinitialize BLE platform');
     return _bleMethodChannel.invokeMethod<void>("deinitialize");
   }
 
@@ -101,7 +101,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
     required ScanMode scanMode,
     required bool requireLocationServicesEnabled,
   }) {
-    _logger?.log(
+    logger?.log(
       'Scan for devices with services:$withServices, scanMode: $scanMode, requireLocationServicesEnabled: $requireLocationServicesEnabled',
     );
     return _bleMethodChannel
@@ -124,7 +124,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
     Map<Uuid, List<Uuid>>? servicesWithCharacteristicsToDiscover,
     Duration? connectionTimeout,
   ) {
-    _logger?.log(
+    logger?.log(
       'Connect to device: $id, servicesWithCharacteristicsToDiscover: $servicesWithCharacteristicsToDiscover, timeout: $connectionTimeout',
     );
     return _bleMethodChannel
@@ -143,7 +143,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
 
   @override
   Future<void> disconnectDevice(String deviceId) {
-    _logger?.log(
+    logger?.log(
       'Disconnect device: $deviceId',
     );
     return _bleMethodChannel.invokeMethod<void>(
@@ -156,7 +156,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
 
   @override
   Stream<void> readCharacteristic(CharacteristicInstance characteristic) {
-    _logger?.log(
+    logger?.log(
       'Read characteristic: $characteristic',
     );
     return _bleMethodChannel
@@ -174,7 +174,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
     CharacteristicInstance characteristic,
     List<int> value,
   ) async {
-    _logger?.log('Write with response to $characteristic, value: $value');
+    logger?.log('Write with response to $characteristic, value: $value');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
             "writeCharacteristicWithResponse",
@@ -189,7 +189,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
     CharacteristicInstance characteristic,
     List<int> value,
   ) async {
-    _logger?.log(
+    logger?.log(
       'Write without response to $characteristic, value: $value',
     );
     return _bleMethodChannel
@@ -206,7 +206,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   Stream<void> subscribeToNotifications(
     CharacteristicInstance characteristic,
   ) {
-    _logger?.log('Start subscribing to notifications for $characteristic');
+    logger?.log('Start subscribing to notifications for $characteristic');
     return _bleMethodChannel
         .invokeMethod<void>(
           "readNotifications",
@@ -221,7 +221,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   Future<void> stopSubscribingToNotifications(
     CharacteristicInstance characteristic,
   ) {
-    _logger?.log('Stop subscribing to notifications for $characteristic');
+    logger?.log('Stop subscribing to notifications for $characteristic');
     return _bleMethodChannel
         .invokeMethod<void>(
           "stopNotifications",
@@ -237,7 +237,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
 
   @override
   Future<int> requestMtuSize(String deviceId, int? mtu) async {
-    _logger?.log('Request mtu size for device: $deviceId with mtuSize: $mtu');
+    logger?.log('Request mtu size for device: $deviceId with mtuSize: $mtu');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
           "negotiateMtuSize",
@@ -251,7 +251,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   @override
   Future<ConnectionPriorityInfo> requestConnectionPriority(
       String deviceId, ConnectionPriority priority) {
-    _logger?.log(
+    logger?.log(
         'Request connection priority for device: $deviceId, priority: $priority');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
@@ -266,7 +266,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
   @override
   Future<Result<Unit, GenericFailure<ClearGattCacheError>?>> clearGattCache(
       String deviceId) {
-    _logger?.log('Clear gatt cache for device: $deviceId');
+    logger?.log('Clear gatt cache for device: $deviceId');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
           "clearGattCache",
@@ -279,7 +279,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
 
   @override
   Future<List<DiscoveredService>> discoverServices(String deviceId) async {
-    _logger?.log('Discover services for device: $deviceId');
+    logger?.log('Discover services for device: $deviceId');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
           'discoverServices',
@@ -292,7 +292,7 @@ class ReactiveBleMobilePlatform extends ReactiveBlePlatform {
 
   @override
   Future<List<DiscoveredService>> getDiscoverServices(String deviceId) async {
-    _logger?.log('Get discovered services for device: $deviceId');
+    logger?.log('Get discovered services for device: $deviceId');
     return _bleMethodChannel
         .invokeMethod<List<int>>(
           'getDiscoveredServices',

--- a/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
+++ b/packages/reactive_ble_platform_interface/lib/src/reactive_ble_platform_interface.dart
@@ -1,4 +1,5 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:reactive_ble_platform_interface/src/logger.dart';
 
 import 'models.dart';
 
@@ -12,6 +13,8 @@ import 'models.dart';
 abstract class ReactiveBlePlatform extends PlatformInterface {
   ReactiveBlePlatform() : super(token: _token);
   static final Object _token = Object();
+
+  Logger? logger;
 
   static ReactiveBlePlatform _instance = _PlaceholderImplementation();
 


### PR DESCRIPTION
As described in #708 the string interpolation can use quite a lot of CPU time, even if the logger is set to `LogLevel.none`.

This PR allows to set the `logger` to null which then removes the string interpolations.