### PR TITLE
Some bug fixes

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/lib/src/ble/ble_device_connector.dart
+++ b/example/lib/src/ble/ble_device_connector.dart
@@ -19,7 +19,7 @@ class BleDeviceConnector extends ReactiveState<ConnectionStateUpdate> {
   final _deviceConnectionController = StreamController<ConnectionStateUpdate>();
 
   // ignore: cancel_subscriptions
-  late StreamSubscription<ConnectionStateUpdate> _connection;
+  StreamSubscription<ConnectionStateUpdate>? _connection;
 
   Future<void> connect(String deviceId) async {
     _logMessage('Start connecting to $deviceId');
@@ -37,7 +37,7 @@ class BleDeviceConnector extends ReactiveState<ConnectionStateUpdate> {
   Future<void> disconnect(String deviceId) async {
     try {
       _logMessage('disconnecting to device: $deviceId');
-      await _connection.cancel();
+      await _connection?.cancel();
     } on Exception catch (e, _) {
       _logMessage("Error disconnecting from a device: $e");
     } finally {

--- a/example/lib/src/ui/device_detail/device_interaction_tab.dart
+++ b/example/lib/src/ui/device_detail/device_interaction_tab.dart
@@ -285,7 +285,7 @@ class _ServiceDiscoveryListState extends State<_ServiceDiscoveryList> {
             child: ExpansionPanelList(
               expansionCallback: (int index, bool isExpanded) {
                 setState(() {
-                  if (isExpanded) {
+                  if (!isExpanded) {
                     _expandedItems.remove(index);
                   } else {
                     _expandedItems.add(index);


### PR DESCRIPTION
# Pull Request

This pull request fixes some problems that I noticed when learning **flutter_reactive_ble**.

## Preparation

Steps I took for launching the app:

- Cloned the project to my Windows PC
- Executed command `flutter config --jdk-dir="c:\Program Files\Java\jdk-17` for setting the Java version
- Executed command `flutter pub get` for resolving dependencies

## Fix problem that app cannot be started

Commit: [Update SDK version for starting the app.](https://github.com/tools400/flutter_reactive_ble/commit/192c57fadc6283e0674aa8a3a31f313780cb3f28)

- Select *Start Debugging* (VSCode) to launch the app
- Error:  `FAILURE: Build failed with an exception.`

Example error message:

```text
Dependency 'androidx.fragment:fragment:1.7.1' requires libraries and applications that
           depend on it to compile against version 34 or later of the
           Android APIs.
```

## Fix error on `LateInitializationError` exception

Commit: [Fix 'LateInitializationError' exception.](https://github.com/tools400/flutter_reactive_ble/commit/15947a0cae2b26bf5c51aad94280abb712bad283)

Steps to reproduce the problem:

- Start App
- Start Scan
- Select any device
- Tap the 'back' arrow to return to the device list
- Error: `LateError (LateInitializationError: Field '_connection@141363709' has not been initialized.)`

## Fix problem that characteristics cannot be expanded

Commit: [Fix expanding characteristics.](https://github.com/tools400/flutter_reactive_ble/commit/f61dbf5de228a259d9ee08a09f2d9b257b68638c)

Steps to reproduce the problem:

- Start App
- Start Scan
- Select any device
- Tap the `Connect` buton
- Tap the `Discover Services` button
- Tap the `down` arrow on a characteristics card to expand the card
- Error: card is not expanded
