### PR TITLE
Example app: Update AGP, gradle, target api, .gitigmore .cxx

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,3 +6,20 @@ Demonstrates how to use the `flutter_reactive_ble` plugin.
 
 For help getting started with Flutter, view our online
 [documentation](http://flutter.dev/).
+
+## Android permissions
+
+The example application requests certain permissions and will display a message similar to the following on launch without them.
+
+> "Authorize the FlutterReactiveBle example app to use Bluetooth and location"
+
+Enable visibility to nearby devices
+
+1. Open the _Settings_
+2. Find and click on _Apps_
+3. Find and click on _flutter_reactive_ble_example_
+4. Scroll to _Permissions : nearby devices_
+5. _Nearby Devices_ should appear in the _not allowed_ section.
+6. Click on _Nearby Devices_ and select _allow_
+
+This permission will persist until you delete the example app from the device.

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -11,3 +11,5 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+
+**/.cxx/

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -31,12 +31,12 @@ android {
 
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
     defaultConfig {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -23,7 +23,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -41,8 +41,8 @@ android {
 
     defaultConfig {
         applicationId "com.signify.hue.reactivebleexample"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdkVersion 34
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.7.0" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "1.8.21" apply false
 }
 

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.0.2" apply false
+    id "com.android.application" version "8.7.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.21" apply false
 }
 

--- a/example/devtools_options.yaml
+++ b/example/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:


### PR DESCRIPTION
Example app updates for android. 

1. Updated the AGP 
2. Updated gradle plugin version
3. Updated target API to Android 34 because that is required for new apps so validated
4. Updated the example .gitignore file to suppress transient .cxx directory
5. Updated the target from java 8 to java 11 as required by dependency changes.

All Android should probably be pushed to Java 11.  There are deprecation warnings around 1_8.

Submitting this in case it is time to update the dependencies and the generated android versions.