### PR TITLE
Improve stack trace of exceptions from read(Characteristic)

### DIFF
--- a/packages/flutter_reactive_ble/lib/src/connected_device_operation.dart
+++ b/packages/flutter_reactive_ble/lib/src/connected_device_operation.dart
@@ -43,16 +43,19 @@ class ConnectedDeviceOperationImpl implements ConnectedDeviceOperation {
       _blePlatform.charValueUpdateStream;
 
   @override
-  Future<List<int>> readCharacteristic(CharacteristicInstance characteristic) {
+  Future<List<int>> readCharacteristic(
+    CharacteristicInstance characteristic,
+  ) async {
     final specificCharacteristicValueStream = characteristicValueStream
         .where((update) => update.characteristic == characteristic)
-        .map((update) => update.result.dematerialize());
+        .map((update) => update.result);
 
-    return _blePlatform
+    final result = await _blePlatform
         .readCharacteristic(characteristic)
         .asyncExpand((_) => specificCharacteristicValueStream)
         .firstWhere((_) => true,
             orElse: () => throw NoBleCharacteristicDataReceived());
+    return result.dematerialize();
   }
 
   @override


### PR DESCRIPTION
Dematerialize exceptions inside readCharacteristic instead of in some stream transformation so the stack trace is the one for the call to readCharacteristic (ending in the user's code that initiated the read that failed) instead of some generic list of stream handling methods.