### PR TITLE
ConnectionQueue can get stuck permanently without a way to recover

### DIFF
--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/DeviceConnector.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/DeviceConnector.kt
@@ -71,11 +71,11 @@ internal class DeviceConnector(
             Single.timer(DeviceConnector.Companion.minTimeMsBeforeDisconnectingIsAllowed - diff, TimeUnit.MILLISECONDS)
                 .doFinally {
                     sendDisconnectedUpdate(deviceId)
-                    disposeSubscriptionsAndRemoveFromQueue()
+                    disposeSubscriptionsAndRemoveFromQueue(deviceId)
                 }.subscribe()
         } else {
             sendDisconnectedUpdate(deviceId)
-            disposeSubscriptionsAndRemoveFromQueue()
+            disposeSubscriptionsAndRemoveFromQueue(deviceId)
         }
     }
 
@@ -83,7 +83,7 @@ internal class DeviceConnector(
         updateListeners(ConnectionUpdateSuccess(deviceId, ConnectionState.DISCONNECTED.code))
     }
 
-    private fun disposeSubscriptionsAndRemoveFromQueue() {
+    private fun disposeSubscriptionsAndRemoveFromQueue(deviceId: String) {
         connectionDisposable?.dispose()
         connectDeviceSubject.onComplete()
         connectionStatusUpdates.dispose()


### PR DESCRIPTION
It is possible that plugin is stuck forever upon receiving lots of connection requests from different device. After thorough investigation it looks like the culprit is the ConnectionQueue that ended up stuck with some dead/orphaned connections that never recover on their own (which is a different story.. potentially requiring diving deeper in RxAndroidBle) and even though the client already lost interest for these connnections and requested a disconnection (and these items are removed from activeConnections in RxBleClient), objects in the queue stay forever.