### PR TITLE
Prevent index out of range crash in Central.swift when filtering services and characteristics

### DIFF
--- a/packages/reactive_ble_mobile/darwin/Classes/ReactiveBle/Central.swift
+++ b/packages/reactive_ble_mobile/darwin/Classes/ReactiveBle/Central.swift
@@ -366,13 +366,21 @@ final class Central {
     private func resolve(characteristic characteristicInstance: CharacteristicInstance) throws -> CBCharacteristic {
         let peripheral = try resolve(connected: characteristicInstance.peripheralID)
 
-        guard let service = peripheral.services?.filter({ $0.uuid == characteristicInstance.serviceID })[Int(characteristicInstance.serviceInstanceID) ?? 0]
+        let filteredServices = peripheral.services?.filter { $0.uuid == characteristicInstance.serviceID } ?? []
+        let serviceIndex = Int(characteristicInstance.serviceInstanceID) ?? 0
+
+        guard serviceIndex >= 0, serviceIndex < filteredServices.count
         else { throw Failure.serviceNotFound(characteristicInstance.serviceID, characteristicInstance.peripheralID) }
 
-        guard let characteristic = service.characteristics?.filter({ $0.uuid == characteristicInstance.id })[Int(characteristicInstance.instanceID) ?? 0]
+        let service = filteredServices[serviceIndex]
+
+        let filteredCharacteristics = service.characteristics?.filter {$0.uuid == characteristicInstance.id} ?? []
+        let characteristicsIndex = Int(characteristicInstance.instanceID) ?? 0
+
+        guard characteristicsIndex >= 0, characteristicsIndex < filteredCharacteristics.count
         else { throw Failure.characteristicNotFound(characteristicInstance) }
 
-        return characteristic
+        return filteredCharacteristics[characteristicsIndex]
     }
 
     private enum Failure: Error, CustomStringConvertible {


### PR DESCRIPTION
Fix to safely access filtered arrays of services and characteristics in Central.swift. Previously, the code accessed array elements directly by index which would cause a runtime error (crash) if the index was out of bounds. Currently, the code checks if the index is within range before accessing the array and throws an exception with a description in case it is not.