### PR TITLE
Handle already-connected BLE devices gracefully

### DIFF
--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/PluginController.kt
@@ -367,9 +367,29 @@ class PluginController {
                 result.success(protoConverter.convertDiscoverServicesInfo(request.deviceId, discoverResult).toByteArray())
             }, {
                     throwable ->
-                result.error("service_discovery_failure", throwable.toString(), throwable.stackTrace.toList().toString())
+                val (code, message) = mapDiscoverServicesError(throwable, request.deviceId)
+                result.error(code, message, throwable.stackTrace.toList().toString())
             })
             .discard()
+    }
+
+    private fun mapDiscoverServicesError(
+        throwable: Throwable,
+        deviceId: String,
+    ): Pair<String, String> {
+        val msg = throwable.message ?: ""
+        val isAlreadyConnected =
+            throwable is com.polidea.rxandroidble2.exceptions.BleAlreadyConnectedException ||
+                msg.contains("Already connected", ignoreCase = true)
+
+        return if (isAlreadyConnected) {
+            "device_already_connected" to
+                "Device $deviceId is already connected at the OS level but is no longer tracked " +
+                "by the plugin. Call disconnectDevice (or restart Bluetooth) before retrying. " +
+                "Original error: $msg"
+        } else {
+            "service_discovery_failure" to throwable.toString()
+        }
     }
 
     private fun readRssi(

--- a/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
+++ b/packages/reactive_ble_mobile/android/src/main/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClient.kt
@@ -283,9 +283,28 @@ open class ReactiveBleClient(private val context: Context) : BleClient {
         timeout: Duration = Duration(0, TimeUnit.MILLISECONDS),
     ): Observable<EstablishConnectionResult> {
         val device = rxBleClient.getBleDevice(deviceId)
-        val connector =
-            activeConnections.getOrPut(deviceId) { createDeviceConnector(device, timeout) }
 
+        activeConnections[deviceId]?.let { existing ->
+            return existing.connection
+        }
+
+        if (device.connectionState == RxBleConnection.RxBleConnectionState.CONNECTED) {
+            // RxAndroidBle already holds a connection for this device but the plugin no longer
+            // tracks a DeviceConnector for it (e.g. after a Flutter hot restart, or when a
+            // previous disconnect did not propagate down to the OS). RxAndroidBle does not
+            // expose a way to adopt the existing GATT, so calling establishConnection again
+            // would throw BleAlreadyConnectedException. Surface an actionable error instead.
+            return Observable.just(
+                EstablishConnectionFailure(
+                    deviceId,
+                    "Device $deviceId is already connected at the OS level but is no longer " +
+                        "tracked by the plugin. Call disconnectDevice (or restart Bluetooth) " +
+                        "before retrying.",
+                ),
+            )
+        }
+
+        val connector = activeConnections.getOrPut(deviceId) { createDeviceConnector(device, timeout) }
         return connector.connection
     }
 

--- a/packages/reactive_ble_mobile/android/src/test/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClientTest.kt
+++ b/packages/reactive_ble_mobile/android/src/test/kotlin/com/signify/hue/flutterreactiveble/ble/ReactiveBleClientTest.kt
@@ -102,6 +102,7 @@ class ReactiveBleClientTest {
         sut.initializeClient()
 
         every { bleDevice.observeConnectionStateChanges() }.returns(Observable.just(RxBleConnection.RxBleConnectionState.CONNECTED))
+        every { bleDevice.connectionState }.returns(RxBleConnection.RxBleConnectionState.DISCONNECTED)
         every { rxBleClient.getBleDevice(any()) }.returns(bleDevice)
         every { deviceConnector.connection }.returns(subject)
 
@@ -406,6 +407,18 @@ class ReactiveBleClientTest {
             subject.onNext(EstablishConnectionFailure("test", "error"))
             val result = sut.discoverServices("test").test()
             result.assertError(Exception::class.java)
+        }
+
+        @Test
+        fun `It surfaces an actionable error when device is connected at OS level but untracked`() {
+            ReactiveBleClient.activeConnections.clear()
+            every { bleDevice.connectionState }.returns(RxBleConnection.RxBleConnectionState.CONNECTED)
+
+            val result = sut.discoverServices("untracked").test()
+
+            result.assertError { throwable ->
+                throwable.message?.contains("already connected at the OS level") == true
+            }
         }
     }
 }


### PR DESCRIPTION
Detect and surface a clear, actionable error when RxAndroidBle already holds a connection that the plugin does not track (e.g. after a hot restart).

- ReactiveBleClient.establishConnection: if the underlying RxBleDevice is CONNECTED but no DeviceConnector is tracked, return an EstablishConnectionFailure Observable with a helpful message instead of triggering BleAlreadyConnectedException.
- PluginController: map discover-services errors and return a "device_already_connected" code and detailed message when the underlying error indicates an already-connected device.
- Tests: adjust connectionState stubbing and add a unit test verifying the actionable error is surfaced for untracked OS-level connections.

This avoids confusing BleAlreadyConnected exceptions and guides callers to disconnect the device (or restart Bluetooth) before retrying.